### PR TITLE
Ignore references that cannot be validated

### DIFF
--- a/src/utils/text_utils.py
+++ b/src/utils/text_utils.py
@@ -1497,7 +1497,7 @@ def parse_bibtex_entries(bib_content):
     return entries
 
 
-def extract_latex_references(text, file_path=None):  # pylint: disable=unused-argument
+def extract_latex_references(text, file_path=None, ignore_keys=None):  # pylint: disable=unused-argument
     """
     Extract references from LaTeX content programmatically
     
@@ -1551,6 +1551,12 @@ def extract_latex_references(text, file_path=None):  # pylint: disable=unused-ar
                 'bibtex_key': entry['key'],
                 'bibtex_type': entry['type']
             }
+
+            if ignore_keys:
+                # If ignore_keys is provided, skip processing this entry
+                if ref['bibtex_key'] in ignore_keys:
+                    logger.info(f"Ignoring BibTeX entry with key: {ref['bibtex_key']}")
+                    continue
             
             # Preserve all original BibTeX fields for formatting correction
             for field_name, field_value in fields.items():

--- a/tests/unit/test_text_utils.py
+++ b/tests/unit/test_text_utils.py
@@ -16,7 +16,8 @@ from utils.text_utils import (
     extract_arxiv_id_from_url,
     clean_author_name,
     normalize_author_name,
-    calculate_title_similarity
+    calculate_title_similarity,
+    extract_latex_references
 )
 
 
@@ -151,3 +152,31 @@ class TestArxivIdExtraction:
             result = extract_arxiv_id_from_url(url)
             # Should return None or handle gracefully
             assert result is None or isinstance(result, str)
+
+class TestBibIgnorefile:
+    """Test ignore file functionality."""
+    
+    def test_ignore_file_processing(self):
+        """Test processing of ignore files."""
+        bib_content = """
+        @article{test_key,
+          title={Test Paper},
+          author={Test Author},
+          year={2023},
+          url={https://arxiv.org/abs/1234.5678}
+        }
+        @article{another_key,
+          title={Another Test Paper},
+          author={Another Author},
+          year={2024},
+          url={https://arxiv.org/abs/2345.6789}
+        }
+        """
+        ignore_keys = ["test_key"]
+        result = extract_latex_references(bib_content, ignore_keys=ignore_keys)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]['bibtex_key'] == "another_key"
+        # Ensure ignored key is not present
+        for ref in result:
+            assert ref['bibtex_key'] != "test_key"


### PR DESCRIPTION
This PR adds a --ignore-file option (defaulting at .refignore) where the user can indicate a list of biblatex ids to skip in the validation phase.

In my usecase I have references that cannot be found, so this is useful to avoid unnecessary warnings