### PR TITLE
Optimize release workflows: remove redundant test dependencies

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -36,7 +36,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-        pip install -r requirements.txt
     
     - name: Configure git
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-        pip install -r requirements.txt
     
     - name: Configure git
       run: |


### PR DESCRIPTION
- Remove pip install -r requirements.txt from build workflows
- Tests are already covered by test.yml workflow on PRs and pushes to main
- Release workflows now only install minimal build dependencies (build, twine)
- Faster CI/CD pipeline with no redundant test execution