### PR TITLE
Refactor biblatex reference logging and enhance venue extraction logic

### DIFF
--- a/src/core/parallel_processor.py
+++ b/src/core/parallel_processor.py
@@ -279,7 +279,8 @@ class ParallelReferenceProcessor:
         from utils.text_utils import format_authors_for_display
         authors = format_authors_for_display(reference.get('authors', []))
         year = reference.get('year', '')
-        venue = reference.get('venue', '')
+        # Get venue from either 'venue' or 'journal' field
+        venue = reference.get('venue', '') or reference.get('journal', '')
         url = reference.get('url', '')
         doi = reference.get('doi', '')
         

--- a/src/core/refchecker.py
+++ b/src/core/refchecker.py
@@ -3383,7 +3383,7 @@ class ArxivReferenceChecker:
         # Check if this is biblatex format  
         from utils.biblatex_parser import detect_biblatex_format
         if detect_biblatex_format(bibliography_text):
-            logger.info("Detected biblatex format, using biblatex parser")
+            logger.debug("Detected biblatex format")
             self.used_regex_extraction = True
             # Note: biblatex parsing is also robust, so we don't set used_unreliable_extraction
             biblatex_refs = self._parse_biblatex_references(bibliography_text)
@@ -3391,7 +3391,7 @@ class ArxivReferenceChecker:
             # If biblatex parsing returned empty results (due to quality validation),
             # fallback to LLM if available
             if not biblatex_refs and self.llm_extractor:
-                logger.debug("Biblatex parser returned no results due to quality validation, trying LLM fallback")
+                logger.debug("Biblatex is incompatible with parser")
                 try:
                     references = self.llm_extractor.extract_references(bibliography_text)
                     if references:
@@ -3403,7 +3403,7 @@ class ArxivReferenceChecker:
                 except Exception as e:
                     logger.error(f"LLM fallback failed: {e}")
                     return []
-            
+            logger.debug("Using biblatex file")               
             return biblatex_refs
         
         # For non-standard formats, try LLM-based extraction if available
@@ -3634,6 +3634,7 @@ class ArxivReferenceChecker:
             # we'll continue with the unreliable fallback regex parsing
             if not biblatex_refs:
                 logger.debug("Biblatex parser returned no results due to quality validation, falling back to regex parsing")
+                print(f"⚠️  Biblatex parser found no valid references (failed quality validation) - falling back to regex parsing")
             else:
                 return biblatex_refs
         

--- a/src/utils/text_utils.py
+++ b/src/utils/text_utils.py
@@ -3006,7 +3006,9 @@ def extract_latex_references(text, file_path=None):  # pylint: disable=unused-ar
                         if ref['year']:
                             venue_clean = re.sub(rf'\b{ref["year"]}\b.*', '', venue_clean)
                         venue_clean = venue_clean.rstrip(',. ')
-                        if venue_clean:
+                        # Filter out common non-venue patterns that shouldn't be treated as venues
+                        non_venue_patterns = ['URL', 'url', 'http:', 'https:', 'DOI', 'doi:', 'ArXiv', 'arxiv:']
+                        if venue_clean and not any(pattern in venue_clean for pattern in non_venue_patterns):
                             ref['journal'] = venue_clean
                 
                 # Extract URL if present


### PR DESCRIPTION
Improve clarity in biblatex reference logging and enhance venue extraction by prioritizing 'venue' or 'journal' fields while filtering out non-venue patterns.