### PR TITLE
Implement venue normalization and cleaning logic with comprehensive regression tests

### DIFF
--- a/src/checkers/openreview_checker.py
+++ b/src/checkers/openreview_checker.py
@@ -473,9 +473,10 @@ class OpenReviewReferenceChecker:
         
         if cited_venue and paper_venue:
             if are_venues_substantially_different(cited_venue, paper_venue):
+                from utils.error_utils import clean_venue_for_comparison
                 errors.append({
                     "warning_type": "venue",
-                    "warning_details": f"Venue mismatch: cited as '{cited_venue}' but OpenReview shows '{paper_venue}'"
+                    "warning_details": f"Venue mismatch: cited as '{clean_venue_for_comparison(cited_venue)}' but OpenReview shows '{clean_venue_for_comparison(paper_venue)}'"
                 })
         
         # Create verified data structure

--- a/src/checkers/semantic_scholar.py
+++ b/src/checkers/semantic_scholar.py
@@ -544,11 +544,8 @@ class NonArxivReferenceChecker:
         if cited_venue and paper_venue:
             # Use the utility function to check if venues are substantially different
             if are_venues_substantially_different(cited_venue, paper_venue):
-                errors.append({
-                    'warning_type': 'venue',
-                    'warning_details': f"Venue mismatch: cited as '{cited_venue}' but actually '{paper_venue}'",
-                    'ref_venue_correct': paper_venue
-                })
+                from utils.error_utils import create_venue_warning
+                errors.append(create_venue_warning(cited_venue, paper_venue))
         elif not cited_venue and paper_venue:
             # Check if this is an arXiv paper first
             external_ids = paper_data.get('externalIds', {})

--- a/src/core/parallel_processor.py
+++ b/src/core/parallel_processor.py
@@ -279,8 +279,11 @@ class ParallelReferenceProcessor:
         from utils.text_utils import format_authors_for_display
         authors = format_authors_for_display(reference.get('authors', []))
         year = reference.get('year', '')
-        # Get venue from either 'venue' or 'journal' field
+        # Get venue from either 'venue' or 'journal' field and clean it up
         venue = reference.get('venue', '') or reference.get('journal', '')
+        if venue:
+            from utils.error_utils import clean_venue_for_comparison
+            venue = clean_venue_for_comparison(venue)
         url = reference.get('url', '')
         doi = reference.get('doi', '')
         

--- a/src/utils/error_utils.py
+++ b/src/utils/error_utils.py
@@ -89,6 +89,20 @@ def create_title_error(error_details: str, correct_title: str) -> Dict[str, str]
     }
 
 
+def clean_venue_for_comparison(venue: str) -> str:
+    """
+    Clean venue name for display in warnings using the shared normalization logic.
+    
+    Args:
+        venue: Raw venue string
+        
+    Returns:
+        Cleaned venue name suitable for display
+    """
+    from utils.text_utils import normalize_venue_for_display
+    return normalize_venue_for_display(venue)
+
+
 def create_venue_warning(cited_venue: str, correct_venue: str) -> Dict[str, str]:
     """
     Create a standardized venue warning dictionary.
@@ -100,9 +114,13 @@ def create_venue_warning(cited_venue: str, correct_venue: str) -> Dict[str, str]
     Returns:
         Standardized warning dictionary
     """
+    # Clean both venues for display in the warning
+    clean_cited = clean_venue_for_comparison(cited_venue)
+    clean_correct = clean_venue_for_comparison(correct_venue)
+    
     return {
         'warning_type': 'venue',
-        'warning_details': f"Venue mismatch: cited as '{cited_venue}' but actually '{correct_venue}'",
+        'warning_details': f"Venue mismatch: cited as '{clean_cited}' but actually '{clean_correct}'",
         'ref_venue_correct': correct_venue
     }
 


### PR DESCRIPTION
- Added `clean_venue_for_comparison` function to standardize venue names for warnings and comparisons.
- Updated `create_venue_warning` to utilize cleaned venue names for improved warning messages.
- Introduced `normalize_venue_for_display` to ensure consistent venue formatting across the system.
- Enhanced `are_venues_substantially_different` to incorporate shared normalization logic for venue comparisons.
- Created multiple regression test files to cover various edge cases in venue matching, cleaning, and parsing.
- Ensured that venues parsed as "In" or empty are filtered out from display outputs.
- Verified that valid venues starting with "In" are correctly displayed without filtering.
- Addressed specific false positive cases in venue comparisons to prevent incorrect warnings.