### PR TITLE
Enhance venue handling and add tests for normalization

### DIFF
--- a/src/core/refchecker.py
+++ b/src/core/refchecker.py
@@ -5181,7 +5181,7 @@ class ArxivReferenceChecker:
             from utils.text_utils import format_authors_for_display
             authors = format_authors_for_display(reference.get('authors', []))
             year = reference.get('year', '')
-            venue = reference.get('venue', '')
+            venue = reference.get('venue', '') or reference.get('journal', '')
             url = reference.get('url', '')
             doi = reference.get('doi', '')
             # Extract actual reference number from raw text for accurate display

--- a/src/utils/text_utils.py
+++ b/src/utils/text_utils.py
@@ -4594,7 +4594,7 @@ def normalize_venue_for_display(venue: str) -> str:
     prefixes_to_remove = [
         r'^\d{4}\s+\d+(st|nd|rd|th)\s+',  # "2012 IEEE/RSJ"
         r'^\d{4}\s+',                     # "2024 "
-        r'^proceedings\s+(of\s+)?(the\s+)?(\d+(st|nd|rd|th)\s+)?(ieee\s+)?',  # "Proceedings of the IEEE"
+        r'^proceedings\s+(of\s+)?(the\s+)?((acm|ieee|usenix|aaai|sigcomm|sigkdd|sigmod|sigops|vldb|osdi|sosp|eurosys)\s+)*(\d+(st|nd|rd|th)\s+)?',  # "Proceedings of the [ORG] [ORG] 29th"
         r'^proc\.\s+of\s+(the\s+)?(\d+(st|nd|rd|th)\s+)?(ieee\s+)?',        # "Proc. of the IEEE" (require "of")
         r'^procs\.\s+of\s+(the\s+)?(\d+(st|nd|rd|th)\s+)?(ieee\s+)?',       # "Procs. of the IEEE" (require "of")
         r'^in\s+',

--- a/src/utils/url_utils.py
+++ b/src/utils/url_utils.py
@@ -214,6 +214,7 @@ def clean_url(url: str) -> str:
     This function handles:
     - Whitespace trimming
     - Malformed LaTeX URL wrappers like \\url{https://...}
+    - Markdown-style links like [text](url)
     - Trailing punctuation from academic references
     - DOI URL query parameter cleanup
     
@@ -236,6 +237,14 @@ def clean_url(url: str) -> str:
     url_match = re.search(url_pattern, url)
     if url_match:
         url = url_match.group(1)
+    
+    # Handle markdown-style links like [text](url) or [url](url)
+    # e.g., "[https://example.com](https://example.com)" -> "https://example.com"
+    markdown_pattern = r'\[([^\]]*)\]\((https?://[^)]+)\)'
+    markdown_match = re.search(markdown_pattern, url)
+    if markdown_match:
+        # Use the URL from parentheses
+        url = markdown_match.group(2)
     
     # Remove trailing punctuation that's commonly part of sentence structure
     # but preserve legitimate URL characters
@@ -279,6 +288,14 @@ def clean_url_punctuation(url: str) -> str:
     url_match = re.search(url_pattern, url)
     if url_match:
         url = url_match.group(1)
+    
+    # Handle markdown-style links like [text](url) or [url](url)
+    # e.g., "[https://example.com](https://example.com)" -> "https://example.com"
+    markdown_pattern = r'\[([^\]]*)\]\((https?://[^)]+)\)'
+    markdown_match = re.search(markdown_pattern, url)
+    if markdown_match:
+        # Use the URL from parentheses
+        url = markdown_match.group(2)
     
     # Remove trailing punctuation that's commonly part of sentence structure
     # but preserve legitimate URL characters

--- a/tests/unit/test_proceedings_ordinal_fix.py
+++ b/tests/unit/test_proceedings_ordinal_fix.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Test suite for proceedings with ordinal numbers fix
+
+This test ensures that venue names like "Proceedings of the ACM SIGOPS 29th Symposium..."
+are correctly normalized to match their canonical forms.
+"""
+
+import unittest
+import sys
+import os
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from utils.text_utils import normalize_venue_for_display, are_venues_substantially_different
+
+
+class TestProceedingsOrdinalFix(unittest.TestCase):
+    """Test proceedings normalization with ordinal numbers"""
+    
+    def test_acm_sigops_29th_symposium(self):
+        """Test the specific case that was failing"""
+        cited_venue = 'Proceedings of the ACM SIGOPS 29th Symposium on Operating Systems Principles'
+        actual_venue = 'Symposium on Operating Systems Principles'
+        
+        # Test normalization
+        normalized_cited = normalize_venue_for_display(cited_venue)
+        normalized_actual = normalize_venue_for_display(actual_venue)
+        
+        self.assertEqual(normalized_cited, 'Symposium on Operating Systems Principles')
+        self.assertEqual(normalized_actual, 'Symposium on Operating Systems Principles')
+        self.assertEqual(normalized_cited, normalized_actual)
+        
+        # Test venue comparison
+        self.assertFalse(are_venues_substantially_different(cited_venue, actual_venue),
+                        "These venues should be considered the same after normalization")
+        
+        # Test that no venue warning would be generated (simulating the checker logic)
+        from utils.error_utils import create_venue_warning
+        should_create_warning = are_venues_substantially_different(cited_venue, actual_venue)
+        self.assertFalse(should_create_warning, 
+                        "No venue warning should be generated for properly normalized venues")
+    
+    def test_ieee_ordinal_conference(self):
+        """Test IEEE proceedings with ordinals"""
+        cited_venue = 'Proceedings of the IEEE 25th International Conference on Computer Vision'
+        actual_venue = 'International Conference on Computer Vision'
+        
+        normalized_cited = normalize_venue_for_display(cited_venue)
+        normalized_actual = normalize_venue_for_display(actual_venue)
+        
+        self.assertEqual(normalized_cited, 'International Conference on Computer Vision')
+        self.assertEqual(normalized_actual, 'International Conference on Computer Vision')
+        self.assertEqual(normalized_cited, normalized_actual)
+        
+        self.assertFalse(are_venues_substantially_different(cited_venue, actual_venue))
+    
+    def test_usenix_osdi_ordinal(self):
+        """Test USENIX OSDI with ordinals"""
+        cited_venue = 'Proceedings of the USENIX OSDI 15th Symposium on Operating Systems Design'
+        actual_venue = 'Symposium on Operating Systems Design'
+        
+        normalized_cited = normalize_venue_for_display(cited_venue)
+        normalized_actual = normalize_venue_for_display(actual_venue)
+        
+        self.assertEqual(normalized_cited, 'Symposium on Operating Systems Design')
+        self.assertEqual(normalized_actual, 'Symposium on Operating Systems Design')
+        self.assertEqual(normalized_cited, normalized_actual)
+        
+        self.assertFalse(are_venues_substantially_different(cited_venue, actual_venue))
+    
+    def test_simple_ordinal_proceedings(self):
+        """Test proceedings with simple ordinals (no org names)"""
+        cited_venue = 'Proceedings of the 29th Conference on Machine Learning'
+        actual_venue = 'Conference on Machine Learning'
+        
+        normalized_cited = normalize_venue_for_display(cited_venue)
+        normalized_actual = normalize_venue_for_display(actual_venue)
+        
+        self.assertEqual(normalized_cited, 'Conference on Machine Learning')
+        self.assertEqual(normalized_actual, 'Conference on Machine Learning')
+        self.assertEqual(normalized_cited, normalized_actual)
+        
+        self.assertFalse(are_venues_substantially_different(cited_venue, actual_venue))
+    
+    def test_neurips_preserved(self):
+        """Test that proceedings without org prefixes are preserved correctly"""
+        # This case should NOT be over-processed
+        venue = 'Proceedings of Neural Information Processing Systems'
+        normalized = normalize_venue_for_display(venue)
+        
+        # Should preserve the full name, not just "Systems"
+        self.assertEqual(normalized, 'Neural Information Processing Systems')
+    
+    def test_multiple_organization_names(self):
+        """Test proceedings with multiple organization acronyms"""
+        cited_venue = 'Proceedings of the ACM SIGCOMM 45th Annual Conference on Data Communication'
+        actual_venue = 'Annual Conference on Data Communication'
+        
+        normalized_cited = normalize_venue_for_display(cited_venue)
+        normalized_actual = normalize_venue_for_display(actual_venue)
+        
+        self.assertEqual(normalized_cited, 'Annual Conference on Data Communication')
+        self.assertEqual(normalized_actual, 'Annual Conference on Data Communication')
+        self.assertEqual(normalized_cited, normalized_actual)
+        
+        self.assertFalse(are_venues_substantially_different(cited_venue, actual_venue))
+    
+    def test_edge_cases(self):
+        """Test edge cases that should not be affected"""
+        test_cases = [
+            # Regular journals should not be affected
+            ('IEEE Transactions on Software Engineering', 'IEEE Transactions on Software Engineering'),
+            
+            # Conference names without proceedings prefix should not be affected
+            ('Neural Information Processing Systems', 'Neural Information Processing Systems'),
+            
+            # Proceedings without ordinals should work as before
+            ('Proceedings of the International Conference on Learning', 'International Conference on Learning'),
+        ]
+        
+        for input_venue, expected_output in test_cases:
+            with self.subTest(venue=input_venue):
+                normalized = normalize_venue_for_display(input_venue)
+                self.assertEqual(normalized, expected_output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_venue_truncation_and_url_brackets.py
+++ b/tests/unit/test_venue_truncation_and_url_brackets.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Test suite for venue truncation and URL bracket formatting fixes
+
+This test ensures that:
+1. Venue names are correctly retrieved from journal field when venue field is empty
+2. Markdown-style URL links are correctly parsed and cleaned
+"""
+
+import unittest
+import sys
+import os
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
+
+from utils.bibtex_parser import parse_bibtex_references
+from utils.url_utils import clean_url
+
+
+class TestVenueTruncationAndUrlBrackets(unittest.TestCase):
+    """Test venue truncation and URL bracket formatting fixes"""
+    
+    def test_venue_field_fallback_to_journal(self):
+        """Test that venue display correctly falls back to journal field"""
+        # Simulate what BibTeX parser creates - venue is empty, journal has the value
+        test_reference = {
+            'title': 'Automatic instruction evolving for large language models',
+            'venue': '',  # Empty as created by BibTeX parser
+            'journal': 'Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics',
+            'authors': ['Test Author'],
+            'year': 2023
+        }
+        
+        # Test the fixed venue field fallback logic (from refchecker.py:5184)
+        venue = test_reference.get('venue', '') or test_reference.get('journal', '')
+        
+        self.assertEqual(venue, 'Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics')
+        self.assertNotEqual(venue, '')  # Should not be empty
+        self.assertNotEqual(venue, 'Proceedings of the')  # Should not be truncated
+    
+    def test_bibtex_parsing_preserves_full_venue(self):
+        """Test that BibTeX parsing correctly maps booktitle to journal field"""
+        test_bibtex = '''
+        @inproceedings{test2023,
+          title={Automatic instruction evolving for large language models},
+          author={Yidong Wang and others},
+          booktitle={Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics},
+          year={2023},
+          pages={4587--4601}
+        }
+        '''
+        
+        references = parse_bibtex_references(test_bibtex)
+        self.assertEqual(len(references), 1)
+        
+        ref = references[0]
+        self.assertEqual(ref['title'], 'Automatic instruction evolving for large language models')
+        self.assertEqual(ref['journal'], 'Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics')
+        # The venue field should be empty or not present (BibTeX parser maps booktitle to journal)
+        self.assertEqual(ref.get('venue', ''), '')
+    
+    def test_markdown_url_cleaning(self):
+        """Test that markdown-style URL links are correctly cleaned"""
+        test_cases = [
+            # Standard markdown link
+            ('[https://huggingface.co/model](https://huggingface.co/model)', 'https://huggingface.co/model'),
+            # Markdown link with different text
+            ('[Model Page](https://huggingface.co/model)', 'https://huggingface.co/model'),
+            # Regular URL should be unchanged
+            ('https://huggingface.co/model', 'https://huggingface.co/model'),
+            # Incomplete markdown (missing closing paren) should be unchanged
+            ('[https://example.com](https://example.com', '[https://example.com](https://example.com'),
+            # Malformed markdown should be unchanged
+            ('[no url here]', '[no url here]'),
+        ]
+        
+        for input_url, expected_output in test_cases:
+            with self.subTest(url=input_url):
+                cleaned = clean_url(input_url)
+                self.assertEqual(cleaned, expected_output)
+    
+    def test_bibtex_markdown_url_extraction(self):
+        """Test that BibTeX parsing correctly handles markdown-style URLs in howpublished field"""
+        test_bibtex = '''
+        @misc{inf_orm_2023,
+          title={Inf-orm-llama3.1-70b},
+          author={Test Author},
+          howpublished={[https://huggingface.co/infly/INF-ORM-Llama3.1-70B](https://huggingface.co/infly/INF-ORM-Llama3.1-70B)},
+          year={2023}
+        }
+        '''
+        
+        references = parse_bibtex_references(test_bibtex)
+        self.assertEqual(len(references), 1)
+        
+        ref = references[0]
+        self.assertEqual(ref['title'], 'Inf-orm-llama3.1-70b')
+        # URL should be extracted from markdown link, not contain brackets
+        self.assertEqual(ref['url'], 'https://huggingface.co/infly/INF-ORM-Llama3.1-70B')
+        self.assertNotIn('[', ref['url'])  # Should not contain markdown brackets
+        self.assertNotIn(']', ref['url'])
+        self.assertNotIn('(', ref['url'])
+        self.assertNotIn(')', ref['url'])
+    
+    def test_bibtex_markdown_url_in_title_field(self):
+        """Test that markdown-style URLs in title field are handled correctly"""
+        test_bibtex = '''
+        @misc{test_title_markdown,
+          title={[https://huggingface.co/model](https://huggingface.co/model)},
+          author={Test Author},
+          year={2023}
+        }
+        '''
+        
+        references = parse_bibtex_references(test_bibtex)
+        self.assertEqual(len(references), 1)
+        
+        ref = references[0]
+        # Title should preserve the original markdown (not cleaned since it's not a URL field)
+        self.assertEqual(ref['title'], '[https://huggingface.co/model](https://huggingface.co/model)')
+        # URL field should be empty since no URL was provided in URL/howpublished fields
+        self.assertEqual(ref['url'], '')
+    
+    def test_combined_venue_and_url_issues(self):
+        """Test a reference that has both venue and URL formatting issues"""
+        test_bibtex = '''
+        @inproceedings{combined_test,
+          title={Test paper with both issues},
+          author={Test Author},
+          booktitle={Proceedings of the 42nd Important Conference on Advanced Topics},
+          howpublished={[https://example.com/paper](https://example.com/paper)},
+          year={2023}
+        }
+        '''
+        
+        references = parse_bibtex_references(test_bibtex)
+        self.assertEqual(len(references), 1)
+        
+        ref = references[0]
+        
+        # Test venue issue fix
+        venue = ref.get('venue', '') or ref.get('journal', '')
+        self.assertEqual(venue, 'Proceedings of the 42nd Important Conference on Advanced Topics')
+        self.assertNotEqual(venue, 'Proceedings of the')  # Should not be truncated
+        
+        # Test URL issue fix  
+        self.assertEqual(ref['url'], 'https://example.com/paper')
+        self.assertNotIn('[', ref['url'])  # Should not contain markdown brackets
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Improve venue handling by implementing a fallback to the journal field when the venue is not provided. Add tests to ensure correct normalization of venue names, particularly for proceedings with ordinal numbers and markdown URL parsing.