### PR TITLE
Reference enrichment + open-access full-text recovery

### DIFF
--- a/src/refchecker/checkers/arxiv_citation.py
+++ b/src/refchecker/checkers/arxiv_citation.py
@@ -768,7 +768,8 @@ class ArXivCitationChecker:
             cited_year=cited_year,
             paper_year=authoritative_year,
             use_flexible_validation=True,
-            context={'arxiv_match': True}
+            context={'arxiv_match': True,
+                     'cited_doi': reference.get('doi') or reference.get('DOI')}
         )
         if year_warning:
             errors.append(year_warning)

--- a/src/refchecker/checkers/crossref.py
+++ b/src/refchecker/checkers/crossref.py
@@ -89,7 +89,7 @@ class CrossRefReferenceChecker:
         params = {
             "query": query,
             "rows": min(limit, 20),  # Limit for performance
-            "select": "DOI,title,author,published,publisher,container-title,type,URL,link,abstract,subject"
+            "select": "DOI,title,author,published,publisher,container-title,type,URL,link,abstract,subject,is-referenced-by-count,references-count,funder"
         }
         
         # Add year filter if provided
@@ -174,7 +174,7 @@ class CrossRefReferenceChecker:
         params = {
             "query.bibliographic": bib_string,
             "rows": min(limit, 20),
-            "select": "DOI,title,author,published,published-print,published-online,issued,created,publisher,container-title,type,URL,link,abstract,subject",
+            "select": "DOI,title,author,published,published-print,published-online,issued,created,publisher,container-title,type,URL,link,abstract,subject,is-referenced-by-count,references-count,funder",
         }
         if year:
             # Widen the window to year±1 for the bib fallback. This is

--- a/src/refchecker/checkers/local_semantic_scholar.py
+++ b/src/refchecker/checkers/local_semantic_scholar.py
@@ -695,7 +695,8 @@ class LocalNonArxivReferenceChecker:
         year_warning = validate_year(
             cited_year=year,
             paper_year=paper_year,
-            year_tolerance=year_tolerance
+            year_tolerance=year_tolerance,
+            context={'cited_doi': reference.get('doi') or reference.get('DOI')}
         )
         if year_warning:
             logger.debug(f"{self._log_prefix}: Year issue - {year_warning.get('warning_details', '')}")

--- a/src/refchecker/checkers/openalex.py
+++ b/src/refchecker/checkers/openalex.py
@@ -92,7 +92,7 @@ class OpenAlexReferenceChecker:
         params = {
             "search": query,
             "per_page": min(limit, 25),  # OpenAlex max per page is 200, but we limit for performance
-            "select": "id,doi,title,display_name,publication_year,authorships,type,open_access,primary_location,locations,referenced_works,ids,cited_by_count,concepts,grants,biblio"
+            "select": "id,doi,title,display_name,publication_year,authorships,type,open_access,primary_location,locations,referenced_works,ids,cited_by_count,concepts,grants,biblio,abstract_inverted_index,publication_date"
         }
         
         # Add year filter if provided
@@ -152,7 +152,7 @@ class OpenAlexReferenceChecker:
         endpoint = f"{self.base_url}/works/doi:{clean_doi}"
         
         params = {
-            "select": "id,doi,title,display_name,publication_year,authorships,type,open_access,primary_location,locations,referenced_works,ids,cited_by_count,concepts,grants,biblio"
+            "select": "id,doi,title,display_name,publication_year,authorships,type,open_access,primary_location,locations,referenced_works,ids,cited_by_count,concepts,grants,biblio,abstract_inverted_index,publication_date"
         }
         
         # Make the request with retries and backoff

--- a/src/refchecker/checkers/semantic_scholar.py
+++ b/src/refchecker/checkers/semantic_scholar.py
@@ -43,6 +43,34 @@ logger = logging.getLogger(__name__)
 config = get_config()
 SIMILARITY_THRESHOLD = config["text_processing"]["similarity_threshold"]
 
+# Single source of truth for the Semantic Scholar `fields` selector. Every
+# endpoint (search, match, DOI, ArXiv, CorpusID, full-record refetch) asks for
+# the SAME rich set so the matched paper that becomes `verified_data` always
+# carries the display signals (abstract, tldr, citationCount, referenceCount,
+# publicationDate, …). build_enrichment() reads exactly these keys; if an
+# endpoint omits them the UI silently loses Abstract / Claim / citation &
+# reference counts even though we asked for them.
+S2_PAPER_FIELDS = (
+    "title,authors,year,externalIds,url,abstract,openAccessPdf,isOpenAccess,"
+    "venue,publicationVenue,journal,tldr,citationCount,referenceCount,"
+    "fieldsOfStudy,s2FieldsOfStudy,publicationTypes,publicationDate"
+)
+
+# Cache-key salt. The on-disk API cache keys on (service, method, query) only —
+# NOT on the requested `fields`. When the field set grows (as it did when
+# tldr/citationCount/referenceCount were added), old cached responses built with
+# the smaller selector are still served, so the rich fields never appear even
+# on a "fresh" run. Bumping this token whenever S2_PAPER_FIELDS changes salts
+# the cache `method`, invalidating those stale, field-poor entries while
+# preserving the deterministic, query-addressed cache for everything current.
+S2_FIELDS_CACHE_VERSION = "f2"
+
+# Rich display keys we expect a complete S2 paper record to carry. Used to
+# decide whether a matched-but-sparse result (search/match endpoints, or a
+# stale cache entry) should be topped up from the authoritative
+# /paper/{paperId} record before it becomes verified_data.
+_S2_RICH_KEYS = ("abstract", "tldr", "citationCount", "referenceCount")
+
 class NonArxivReferenceChecker:
     """
     A class to verify non-arXiv references using the Semantic Scholar API
@@ -94,11 +122,12 @@ class NonArxivReferenceChecker:
         """
         from refchecker.utils.cache_utils import cached_api_response, cache_api_response
         cache_q = f"{query}|{year}"
-        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'search_paper', cache_q)
+        method = f"search_paper_{S2_FIELDS_CACHE_VERSION}"
+        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, cache_q)
         if hit is not None:
             return hit
         result = self._search_paper_uncached(query, year)
-        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'search_paper', cache_q, result)
+        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, cache_q, result)
         return result
 
     def _search_paper_uncached(self, query: str, year: Optional[int] = None) -> List[Dict[str, Any]]:
@@ -110,7 +139,7 @@ class NonArxivReferenceChecker:
         params = {
             "query": query,
             "limit": 10,
-            "fields": "title,authors,year,externalIds,url,abstract,openAccessPdf,isOpenAccess,venue,publicationVenue,journal",
+            "fields": S2_PAPER_FIELDS,
             "sort": "relevance"  # Ensure consistent ordering
         }
         
@@ -149,18 +178,19 @@ class NonArxivReferenceChecker:
     
     def get_paper_by_doi(self, doi: str) -> Optional[Dict[str, Any]]:
         from refchecker.utils.cache_utils import cached_api_response, cache_api_response
-        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'get_by_doi', doi)
+        method = f"get_by_doi_{S2_FIELDS_CACHE_VERSION}"
+        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, doi)
         if hit is not None:
             return hit
         result = self._get_paper_by_doi_uncached(doi)
-        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'get_by_doi', doi, result)
+        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, doi, result)
         return result
 
     def _get_paper_by_doi_uncached(self, doi: str) -> Optional[Dict[str, Any]]:
         endpoint = f"{self.base_url}/paper/DOI:{doi}"
-        
+
         params = {
-            "fields": "title,authors,year,externalIds,url,abstract,openAccessPdf,isOpenAccess,venue,publicationVenue,journal"
+            "fields": S2_PAPER_FIELDS
         }
         
         # Make the request with retries and backoff
@@ -200,17 +230,18 @@ class NonArxivReferenceChecker:
     def get_paper_by_arxiv_id(self, arxiv_id: str) -> Optional[Dict[str, Any]]:
         from refchecker.utils.cache_utils import cached_api_response, cache_api_response
         clean_id = re.sub(r'v\d+$', '', arxiv_id.strip().rstrip('.'))
-        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'get_by_arxiv', clean_id)
+        method = f"get_by_arxiv_{S2_FIELDS_CACHE_VERSION}"
+        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, clean_id)
         if hit is not None:
             return hit
         result = self._get_paper_by_arxiv_id_uncached(clean_id)
-        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'get_by_arxiv', clean_id, result)
+        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, clean_id, result)
         return result
 
     def _get_paper_by_arxiv_id_uncached(self, clean_id: str) -> Optional[Dict[str, Any]]:
         endpoint = f"{self.base_url}/paper/ARXIV:{clean_id}"
         params = {
-            "fields": "title,authors,year,externalIds,url,abstract,openAccessPdf,isOpenAccess,venue,publicationVenue,journal"
+            "fields": S2_PAPER_FIELDS
         }
 
         for attempt in range(2):  # Only 2 attempts for fast-path
@@ -234,18 +265,19 @@ class NonArxivReferenceChecker:
 
     def match_paper_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         from refchecker.utils.cache_utils import cached_api_response, cache_api_response
-        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'match_title', title)
+        method = f"match_title_{S2_FIELDS_CACHE_VERSION}"
+        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, title)
         if hit is not None:
             return hit
         result = self._match_paper_by_title_uncached(title)
-        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', 'match_title', title, result)
+        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, title, result)
         return result
 
     def _match_paper_by_title_uncached(self, title: str) -> Optional[Dict[str, Any]]:
         endpoint = f"{self.base_url}/paper/search/match"
         params = {
             "query": title,
-            "fields": "title,authors,year,externalIds,url,abstract,openAccessPdf,isOpenAccess,venue,publicationVenue,journal"
+            "fields": S2_PAPER_FIELDS
         }
 
         for attempt in range(2):  # Only 2 attempts for fast-path
@@ -269,6 +301,91 @@ class NonArxivReferenceChecker:
                     continue
                 return None
         return None
+
+    def get_paper_by_id(self, paper_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch the full S2 record for a paperId via the authoritative
+        /paper/{paperId} endpoint.
+
+        The search and match endpoints frequently return a SPARSE paper object
+        that omits tldr/citationCount/referenceCount even when the `fields`
+        selector requests them. The single-paper endpoint reliably honours the
+        full selector, so we use it to top up a matched-but-incomplete result.
+        Cached (salted with the field-set version) so repeat runs are free."""
+        from refchecker.utils.cache_utils import cached_api_response, cache_api_response
+        pid = str(paper_id).strip()
+        if not pid:
+            return None
+        method = f"get_by_id_{S2_FIELDS_CACHE_VERSION}"
+        hit = cached_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, pid)
+        if hit is not None:
+            return hit
+        result = self._get_paper_by_id_uncached(pid)
+        cache_api_response(getattr(self, 'cache_dir', None), 'semantic_scholar', method, pid, result)
+        return result
+
+    def _get_paper_by_id_uncached(self, paper_id: str) -> Optional[Dict[str, Any]]:
+        endpoint = f"{self.base_url}/paper/{paper_id}"
+        params = {"fields": S2_PAPER_FIELDS}
+        for attempt in range(2):  # fast-path: this is a display nicety, don't stall
+            try:
+                response = self._session.get(endpoint, params=params, timeout=15)
+                if response.status_code == 200:
+                    return response.json()
+                if response.status_code in (404, 400):
+                    return None
+                if response.status_code == 429:
+                    time.sleep(self.request_delay * (self.backoff_factor ** attempt))
+                    continue
+                return None
+            except requests.exceptions.RequestException:
+                if attempt == 0:
+                    time.sleep(0.5)
+                    continue
+                return None
+        return None
+
+    def _enrich_matched_paper(self, paper_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Top up a matched paper with the rich display fields (abstract, tldr,
+        citationCount, referenceCount, …) when the endpoint/cache that produced
+        it returned a sparse object.
+
+        Why this exists: the matched `paper_data` becomes `verified_data`, which
+        build_enrichment() reads to populate Abstract / Claim (tldr) / citation &
+        reference counts on the reference card. Search and match responses (and
+        stale cache entries) often DROP those keys despite the field request, so
+        the card showed nothing but the externalIds-derived link chips. When any
+        expected rich key is missing AND we have a paperId, refetch the full
+        record and merge in ONLY the missing real values — never overwrite an
+        existing value, never fabricate. Returns the same dict (possibly
+        mutated) so callers can keep using it in place."""
+        if not isinstance(paper_data, dict):
+            return paper_data
+
+        # Already complete? Nothing to do.
+        if all(paper_data.get(k) not in (None, "", [], {}) for k in _S2_RICH_KEYS):
+            return paper_data
+
+        paper_id = paper_data.get('paperId')
+        if not paper_id:
+            return paper_data
+
+        try:
+            full = self.get_paper_by_id(paper_id)
+        except Exception as exc:  # display nicety — never break verification
+            logger.debug(f"S2 full-record enrichment failed for {paper_id}: {exc}")
+            return paper_data
+        if not isinstance(full, dict):
+            return paper_data
+
+        # Merge ONLY keys the matched record is genuinely missing, with a real
+        # (non-empty) value in the full record. Real-data only — absent stays
+        # absent so build_enrichment can still distinguish "no signal".
+        for key, value in full.items():
+            if value in (None, "", [], {}):
+                continue
+            if paper_data.get(key) in (None, "", [], {}):
+                paper_data[key] = value
+        return paper_data
 
     def get_venue_from_paper_data(self, paper_data: Dict[str, Any]) -> Optional[str]:
         """
@@ -690,7 +807,7 @@ class NonArxivReferenceChecker:
                 corpus_id = corpus_match.group(1)
                 # Try to get the paper directly by CorpusID
                 endpoint = f"{self.base_url}/paper/CorpusId:{corpus_id}"
-                params = {"fields": "title,authors,year,externalIds,url,abstract,openAccessPdf,isOpenAccess,venue,publicationVenue,journal"}
+                params = {"fields": S2_PAPER_FIELDS}
                 
                 for attempt in range(self.max_retries):
                     try:
@@ -1034,7 +1151,8 @@ class NonArxivReferenceChecker:
             cited_year=year,
             paper_year=paper_year,
             use_flexible_validation=True,
-            context={'arxiv_match': arxiv_id_match}
+            context={'arxiv_match': arxiv_id_match,
+                     'cited_doi': reference.get('doi') or reference.get('DOI')}
         )
         if year_warning:
             errors.append(year_warning)
@@ -1072,8 +1190,11 @@ class NonArxivReferenceChecker:
         
         # Check venue mismatches
         if cited_venue and paper_venue:
-            # Use the utility function to check if venues are substantially different
-            if are_venues_substantially_different(cited_venue, paper_venue):
+            # Use the utility function to check if venues are substantially different.
+            # Pass the title so multi-journal reporting-guideline co-publications
+            # (PRISMA cited as BMJ, matched to the PLoS Medicine copy) aren't flagged.
+            _ref_title = reference.get('title') or paper_data.get('title')
+            if are_venues_substantially_different(cited_venue, paper_venue, paper_title=_ref_title):
                 from refchecker.utils.error_utils import create_venue_warning
                 errors.append(create_venue_warning(cited_venue, paper_venue))
         elif not cited_venue and paper_venue:
@@ -1180,7 +1301,14 @@ class NonArxivReferenceChecker:
         if not paper_url:
             logger.debug(f"No URL found in paper data - available fields: {list(paper_data.keys())}")
             logger.debug(f"Paper data sample: {str(paper_data)[:200]}...")
-        
+
+        # Top up the matched record with the rich display fields (abstract,
+        # tldr, citationCount, referenceCount) when the endpoint that found it
+        # returned a sparse object. This is what becomes `verified_data`, so the
+        # reference card's Abstract / Claim / citation & reference counts depend
+        # on it carrying those fields. No-op when already complete or no paperId.
+        paper_data = self._enrich_matched_paper(paper_data)
+
         return paper_data, errors, paper_url
     
     def _get_paper_from_arxiv_api(self, arxiv_id: str) -> Optional[Dict[str, Any]]:

--- a/src/refchecker/utils/enrichment.py
+++ b/src/refchecker/utils/enrichment.py
@@ -17,6 +17,10 @@ Fields produced:
     mag_id               str   — Microsoft Academic Graph ID (legacy)
     fields_of_study      list  — top concept display names
     publication_type     str   — journal-article / preprint / book / …
+    is_preprint          bool  — True only when type is preprint/posted-content
+    abstract             str   — abstract text (S2/Crossref/OpenAlex), ≤1500 chars
+    tldr                 str   — Semantic Scholar machine TL;DR ("claim")
+    oa_pdf_url           str   — open-access PDF URL when one exists
     has_funding          bool  — at least one grant/funder listed
     funders              list  — distinct funder display names
     has_affiliation      bool  — at least one author has an institution
@@ -29,8 +33,13 @@ Anything we can't extract is left out of the dict — the UI treats
 missing fields as "no signal" rather than zero.
 """
 
+import logging
+import threading
+import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_get(d: Dict[str, Any], *path: str, default: Any = None) -> Any:
@@ -42,6 +51,49 @@ def _safe_get(d: Dict[str, Any], *path: str, default: Any = None) -> Any:
         if cur is None:
             return default
     return cur
+
+
+def _coerce_int(v: Any) -> Optional[int]:
+    """Best-effort non-negative int from a count field. Accepts int or a
+    clean numeric string ("182", "182.0"); rejects everything else.
+    Returns None — never invents a value — so callers can distinguish
+    "no signal" from a real zero."""
+    if isinstance(v, bool):  # bool is a subclass of int — exclude it
+        return None
+    if isinstance(v, int):
+        return v if v >= 0 else None
+    if isinstance(v, float):
+        return int(v) if v >= 0 else None
+    if isinstance(v, str):
+        s = v.strip()
+        if not s:
+            return None
+        try:
+            f = float(s)
+        except (TypeError, ValueError):
+            return None
+        return int(f) if f >= 0 else None
+    return None
+
+
+def _max_count(verified_data: Dict[str, Any], *keys: str) -> Optional[int]:
+    """Coalesce a count across every source-shaped key present in the SAME
+    payload and keep the richest (largest) real value. A payload can carry
+    several source variants at once (OpenAlex `cited_by_count`,
+    Semantic Scholar `citationCount`, Crossref `is-referenced-by-count`),
+    and any one of them may be 0/None while another holds the real number.
+    Taking the max across all present, parseable values means a real 0 is
+    never picked over a real 182, and a missing primary source no longer
+    suppresses a populated secondary one. Returns None when no key carries
+    a parseable value — real-data only, nothing fabricated."""
+    best: Optional[int] = None
+    for k in keys:
+        n = _coerce_int(verified_data.get(k))
+        if n is None:
+            continue
+        if best is None or n > best:
+            best = n
+    return best
 
 
 def _short_id(openalex_url: Optional[str]) -> Optional[str]:
@@ -118,6 +170,57 @@ def _fields_of_study_from_openalex(concepts: List[Dict[str, Any]]) -> List[str]:
     return [c.get('display_name') for c in ranked[:3] if c.get('display_name')]
 
 
+def _strip_jats(s: str) -> str:
+    """Strip JATS/XML tags (Crossref abstracts arrive as <jats:p>…</jats:p>)."""
+    import re as _re
+    s = _re.sub(r'<[^>]+>', ' ', s)
+    s = _re.sub(r'\s+', ' ', s)
+    return s.strip()
+
+
+def _reconstruct_inverted_index(inv: Any, cap: int = 1500) -> Optional[str]:
+    """Rebuild abstract text from OpenAlex `abstract_inverted_index`
+    ({word: [positions]}). Each word is placed at every one of its positions;
+    the result is ordered by position and capped at *cap* chars. Returns None on
+    empty/bad input — never fabricates."""
+    if not isinstance(inv, dict) or not inv:
+        return None
+    positions: List[tuple] = []
+    for word, idxs in inv.items():
+        if not isinstance(idxs, list):
+            continue
+        for i in idxs:
+            if isinstance(i, int) and i >= 0:
+                positions.append((i, word))
+    if not positions:
+        return None
+    positions.sort(key=lambda t: t[0])
+    text = " ".join(w for _i, w in positions).strip()
+    return text[:cap] if text else None
+
+
+def _extract_abstract(verified_data: Dict[str, Any], cap: int = 1500) -> Optional[str]:
+    """First real abstract wins: S2/Crossref plain string (JATS-stripped) →
+    OpenAlex inverted index. Never synthesized from title/other fields."""
+    abs_raw = verified_data.get('abstract')
+    if isinstance(abs_raw, str) and abs_raw.strip():
+        text = abs_raw.strip()
+        if '<' in text and '>' in text:
+            text = _strip_jats(text)
+        return text[:cap] if text else None
+    return _reconstruct_inverted_index(verified_data.get('abstract_inverted_index'), cap=cap)
+
+
+def _extract_oa_pdf_url(verified_data: Dict[str, Any]) -> Optional[str]:
+    """Open-access PDF URL: S2 openAccessPdf.url → OpenAlex open_access.oa_url →
+    primary_location.pdf_url. Returns None when no real OA link exists."""
+    for path in (('openAccessPdf', 'url'), ('open_access', 'oa_url'), ('primary_location', 'pdf_url')):
+        v = _safe_get(verified_data, *path)
+        if isinstance(v, str) and v.startswith('http'):
+            return v
+    return None
+
+
 def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Project the heterogeneous verified payload onto a flat
     display-ready dict. Returns {} when there's nothing to surface."""
@@ -126,14 +229,21 @@ def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 
     enrichment: Dict[str, Any] = {}
 
-    # cited_by_count: OpenAlex top-level; Semantic Scholar uses
-    # `citationCount`; Crossref puts it in `is-referenced-by-count`.
-    cited_by = (
-        verified_data.get('cited_by_count')
-        or verified_data.get('citationCount')
-        or verified_data.get('is-referenced-by-count')
+    # cited_by_count: OpenAlex top-level `cited_by_count`; Semantic Scholar
+    # uses `citationCount`; Crossref puts it in `is-referenced-by-count`.
+    # Coalesce across EVERY variant present in the same payload and keep the
+    # richest (largest) real value — so a source that returned 0 (or omitted
+    # the field) never masks another source's real count, and the UI shows
+    # the maximum confirmable citation number rather than dropping the field.
+    cited_by = _max_count(
+        verified_data,
+        'cited_by_count',
+        'citationCount',
+        'is-referenced-by-count',
+        'citation_count',
+        'numCitedBy',
     )
-    if isinstance(cited_by, int):
+    if cited_by is not None:
         enrichment['cited_by_count'] = cited_by
 
     # Citing-Patents counter — OpenAlex exposes this in
@@ -150,18 +260,23 @@ def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         except (TypeError, ValueError):
             pass
 
-    # reference_count: OpenAlex `referenced_works` array length; S2
-    # may include `referenceCount`; Crossref `references-count`.
-    ref_count: Optional[int] = None
+    # reference_count: OpenAlex `referenced_works` array length; S2 may
+    # include `referenceCount`; Crossref `references-count`. Coalesce
+    # across all variants and keep the richest (largest) value rather than
+    # short-circuiting on the first key seen — an empty `referenced_works`
+    # list (length 0) must NOT suppress a real Crossref `references-count`
+    # carried in the same payload. The array-length and the integer counts
+    # are pooled together; the maximum real value wins.
+    ref_candidates: List[int] = []
     refs = verified_data.get('referenced_works')
     if isinstance(refs, list):
-        ref_count = len(refs)
-    elif isinstance(verified_data.get('referenceCount'), int):
-        ref_count = verified_data['referenceCount']
-    elif isinstance(verified_data.get('references-count'), int):
-        ref_count = verified_data['references-count']
-    if ref_count is not None:
-        enrichment['reference_count'] = ref_count
+        ref_candidates.append(len(refs))
+    for k in ('referenceCount', 'references-count', 'reference_count', 'numReferences'):
+        n = _coerce_int(verified_data.get(k))
+        if n is not None:
+            ref_candidates.append(n)
+    if ref_candidates:
+        enrichment['reference_count'] = max(ref_candidates)
 
     # Open access flag (OpenAlex; Crossref expresses via license[].URL).
     oa_flag = _safe_get(verified_data, 'open_access', 'is_oa')
@@ -201,26 +316,45 @@ def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     if isinstance(pub_type, str) and pub_type:
         enrichment['publication_type'] = pub_type
 
-    # Venue / journal name — OpenAlex uses `primary_location.source.display_name`,
-    # Crossref puts the journal title in `container-title` (list), Semantic Scholar
-    # uses `venue` (str) or `publicationVenue.name`.
+    # Venue / journal name — every source names this differently, so walk
+    # ALL of them and take the first non-empty real value. OpenAlex uses
+    # `primary_location.source.display_name`; Crossref puts the journal
+    # title in `container-title` (list) or `journal-title`/`short-container-title`;
+    # Semantic Scholar uses `venue` (str), `publicationVenue.name`, or a
+    # nested `journal.name`. Coalescing across every variant means a paper
+    # that matched via a source missing its primary venue key still shows
+    # the venue when ANY source in the payload carries it.
+    def _first_str(*vals: Any) -> Optional[str]:
+        for v in vals:
+            if isinstance(v, list) and v:
+                v = v[0]
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+        return None
+
     venue_name = None
     if isinstance(venue_struct, dict):
-        venue_name = venue_struct.get('name') or venue_struct.get('display_name')
+        venue_name = _first_str(venue_struct.get('name'), venue_struct.get('display_name'))
     if not venue_name:
         primary = verified_data.get('primary_location')
         if isinstance(primary, dict):
             src = primary.get('source')
             if isinstance(src, dict):
-                venue_name = src.get('display_name')
+                venue_name = _first_str(src.get('display_name'), src.get('name'))
     if not venue_name:
-        venue_name = verified_data.get('venue')
+        journal = verified_data.get('journal')
+        if isinstance(journal, dict):
+            venue_name = _first_str(journal.get('name'), journal.get('display_name'))
+        elif isinstance(journal, str):
+            venue_name = _first_str(journal)
     if not venue_name:
-        ct = verified_data.get('container-title')
-        if isinstance(ct, list) and ct:
-            venue_name = ct[0]
-        elif isinstance(ct, str):
-            venue_name = ct
+        venue_name = _first_str(
+            verified_data.get('venue'),
+            verified_data.get('container-title'),
+            verified_data.get('journal-title'),
+            verified_data.get('journalName'),
+            verified_data.get('short-container-title'),
+        )
     if isinstance(venue_name, str) and venue_name.strip():
         enrichment['venue'] = venue_name.strip()
 
@@ -270,12 +404,28 @@ def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     if pub_date_str:
         enrichment['publication_date'] = pub_date_str
 
-    # Fields of study — OpenAlex concepts; S2 has `fieldsOfStudy`.
+    # Fields of study — OpenAlex `concepts`; Semantic Scholar exposes a
+    # plain `fieldsOfStudy` (list[str]) AND a richer `s2FieldsOfStudy`
+    # (list[{category, source}]). Walk every variant in turn so a payload
+    # that only carries the S2 structured form (or only OpenAlex concepts)
+    # still surfaces a Field of Study chip. First non-empty real list wins;
+    # capped at three for the strip.
     fos = _fields_of_study_from_openalex(verified_data.get('concepts') or [])
     if not fos:
         s2_fos = verified_data.get('fieldsOfStudy')
         if isinstance(s2_fos, list):
-            fos = [f for f in s2_fos[:3] if f]
+            fos = [f for f in s2_fos if isinstance(f, str) and f.strip()][:3]
+    if not fos:
+        s2_struct_fos = verified_data.get('s2FieldsOfStudy')
+        if isinstance(s2_struct_fos, list):
+            seen_fos = set()
+            for item in s2_struct_fos:
+                cat = item.get('category') if isinstance(item, dict) else item
+                if isinstance(cat, str) and cat.strip() and cat not in seen_fos:
+                    seen_fos.add(cat)
+                    fos.append(cat.strip())
+                if len(fos) >= 3:
+                    break
     if fos:
         enrichment['fields_of_study'] = fos
 
@@ -287,49 +437,115 @@ def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     # fetch it). We surface SOMETHING in all three cases so the FE's
     # AuthorsLine renders a hover for the cited name even when the
     # backing DB doesn't expose author profile IDs.
-    authorships = verified_data.get('authorships')
-    s2_authors_raw: List[Dict[str, Any]] = []
-    if not authorships:
-        # Crossref shape
-        if isinstance(verified_data.get('author'), list):
-            authorships = verified_data['author']
-        # Semantic Scholar shape — promote {authorId, name} into
-        # OpenAlex-shaped {author: {display_name}}. We deliberately
-        # omit `id` because S2's authorId is NOT an OpenAlex ID and
-        # would produce a broken openalex.org/<id> link in the FE.
-        # `s2_author_id` is stored separately so a future FE pass can
-        # link to semanticscholar.org/author/<id>.
-        elif isinstance(verified_data.get('authors'), list):
-            for a in verified_data['authors']:
+    def _s2_authors_to_authorships(raw: Any) -> List[Dict[str, Any]]:
+        """Promote Semantic Scholar `authors` ({authorId, name}) into the
+        OpenAlex-shaped {author: {display_name}}. We deliberately omit `id`
+        because S2's authorId is NOT an OpenAlex ID and would produce a
+        broken openalex.org/<id> link in the FE; `s2_author_id` is stored
+        separately so the FE can link to semanticscholar.org/author/<id>."""
+        out: List[Dict[str, Any]] = []
+        if isinstance(raw, list):
+            for a in raw:
                 if isinstance(a, dict) and a.get('name'):
                     entry = {'author': {'display_name': a.get('name')}}
                     if a.get('authorId'):
                         entry['s2_author_id'] = a.get('authorId')
-                    s2_authors_raw.append(entry)
-            authorships = s2_authors_raw
-    enriched_authors = _extract_authors_with_orcid(authorships or [])
+                    out.append(entry)
+        return out
+
+    # Authors — multi-shape adapter that coalesces across every author key a
+    # source might carry (OpenAlex `authorships`, Crossref `author`,
+    # Semantic Scholar `authors`). Rather than stopping at the first
+    # non-empty key, normalise EACH present shape and keep the richest
+    # result — the list with the most names, breaking ties toward whichever
+    # carries the most ORCID/OpenAlex IDs. That way a payload whose primary
+    # author key is empty/sparse still shows the fullest real author list
+    # another source provided. Never fabricated.
+    candidate_author_lists: List[List[Dict[str, Any]]] = []
+    for raw in (
+        verified_data.get('authorships'),
+        verified_data.get('author') if isinstance(verified_data.get('author'), list) else None,
+    ):
+        if isinstance(raw, list) and raw:
+            candidate_author_lists.append(_extract_authors_with_orcid(raw))
+    s2_shaped = _s2_authors_to_authorships(verified_data.get('authors'))
+    if s2_shaped:
+        candidate_author_lists.append(_extract_authors_with_orcid(s2_shaped))
+
+    enriched_authors: List[Dict[str, Any]] = []
+    for cand in candidate_author_lists:
+        if not cand:
+            continue
+        cand_ids = sum(1 for a in cand if a.get('orcid') or a.get('openalex_id'))
+        best_ids = sum(1 for a in enriched_authors if a.get('orcid') or a.get('openalex_id'))
+        if (len(cand), cand_ids) > (len(enriched_authors), best_ids):
+            enriched_authors = cand
     if enriched_authors:
         enrichment['authors'] = enriched_authors
 
-    # Funders / grants — OpenAlex returns `grants[]` with funder name.
-    grants = verified_data.get('grants')
-    if isinstance(grants, list) and grants:
-        funders = []
-        seen = set()
-        for g in grants:
-            if not isinstance(g, dict):
-                continue
-            name = g.get('funder_display_name') or g.get('funder') or g.get('award_id')
-            if name and name not in seen:
+    # Funders / grants — OpenAlex returns `grants[]` with funder name;
+    # Crossref/S2-shaped payloads may carry a `funders[]`/`funder[]` list of
+    # {name|funder_display_name|funder}. Walk every variant present and pool the
+    # distinct real funder names. Real-data only: if nothing names a funder, the
+    # has_funding/funders keys are omitted (absence != "no funding").
+    funders: List[str] = []
+    seen: set = set()
+    for source_key in ('grants', 'funders', 'funder'):
+        entries = verified_data.get(source_key)
+        if not isinstance(entries, list):
+            continue
+        for g in entries:
+            if isinstance(g, dict):
+                name = (
+                    g.get('funder_display_name')
+                    or g.get('name')
+                    or g.get('funder')
+                    or g.get('award_id')
+                )
+            elif isinstance(g, str):
+                name = g
+            else:
+                name = None
+            if name and str(name) not in seen:
                 funders.append(str(name))
-                seen.add(name)
-        if funders:
-            enrichment['has_funding'] = True
-            enrichment['funders'] = funders[:5]
+                seen.add(str(name))
+    if funders:
+        enrichment['has_funding'] = True
+        enrichment['funders'] = funders[:5]
 
     # Affiliation badge — at least one author institution present.
     if any(a.get('institutions') for a in (enrichment.get('authors') or [])):
         enrichment['has_affiliation'] = True
+
+    # Abstract — first real source wins (S2/Crossref string or OpenAlex
+    # inverted index); omitted entirely when no source carries one.
+    abstract = _extract_abstract(verified_data)
+    if abstract:
+        enrichment['abstract'] = abstract
+
+    # TL;DR / "claim" — ONLY Semantic Scholar's machine-generated tldr.
+    # Never synthesized from the abstract/title. S2's API returns it nested as
+    # {model, text}; some flattened shapes (local DB rows, re-serialised
+    # payloads) carry it as a plain string. Accept either real form; absent
+    # stays absent.
+    tldr_raw = verified_data.get('tldr')
+    tldr = None
+    if isinstance(tldr_raw, dict):
+        tldr = tldr_raw.get('text')
+    elif isinstance(tldr_raw, str):
+        tldr = tldr_raw
+    if isinstance(tldr, str) and tldr.strip():
+        enrichment['tldr'] = tldr.strip()
+
+    # Open-access PDF URL (also added to links below).
+    oa_pdf_url = _extract_oa_pdf_url(verified_data)
+    if oa_pdf_url:
+        enrichment['oa_pdf_url'] = oa_pdf_url
+
+    # Preprint flag — omit when not a preprint (absence != False in the UI).
+    _ptype = (enrichment.get('publication_type') or '').lower()
+    if _ptype in ('preprint', 'posted-content'):
+        enrichment['is_preprint'] = True
 
     # Bibliographic detail (volume / issue / pages) — OpenAlex `biblio`
     # is exactly this shape; Crossref scatters them across top-level
@@ -386,6 +602,8 @@ def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         links['worldcat'] = f"https://www.worldcat.org/search?q={quote(clean_doi, safe='')}"
     if enrichment.get('openalex_id'):
         links['openalex'] = f"https://openalex.org/{enrichment['openalex_id']}"
+    if oa_pdf_url:
+        links['oa_pdf'] = oa_pdf_url
     if links:
         enrichment['links'] = links
 
@@ -412,3 +630,285 @@ def build_enrichment(verified_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         enrichment['verified_by'] = [enrichment['source_label']]
 
     return enrichment
+
+
+# --------------------------------------------------------------------------- #
+# Cross-source backfill (R21 / R22)                                            #
+#                                                                             #
+# When a non-Semantic-Scholar source (DBLP, ACL Anthology, arXiv, Crossref,   #
+# …) wins the verification race, the winning `verified_data` payload often     #
+# lacks the richest display signals — citation/reference COUNTS, the abstract, #
+# the S2 machine TL;DR ("claim"), and funding. `build_enrichment` already      #
+# coalesces ACROSS every variant present in ONE payload, but it cannot         #
+# surface a signal no source put in the payload. `backfill_enrichment` closes  #
+# that gap: given a winning payload + the cited reference, it resolves the      #
+# canonical DOI and pulls the missing-only fields from OpenAlex / Crossref /    #
+# Semantic Scholar by DOI, then merges them into the SAME `verified_data` dict  #
+# so the existing `build_enrichment` projection surfaces them — with NO        #
+# frontend change.                                                             #
+#                                                                             #
+# Contract (mirrors `_enrich_matched_paper` in semantic_scholar.py:380-388):   #
+#   * NEVER overwrite a real existing value — merge only into keys the payload  #
+#     lacks or whose value is empty (None / '' / [] / {}).                      #
+#   * NEVER fabricate — only real provider-returned values are merged; a        #
+#     source that errors/times-out/returns nothing simply contributes nothing.  #
+#   * SOFT-FAIL — any exception (network, parse, timeout) is swallowed; the     #
+#     verification result is never broken by a display nicety.                  #
+#   * BOUNDED — per-DOI TTL cache + 1 retry + short timeout per source + a      #
+#     global concurrency cap, so a 30+ ref bibliography never stalls.           #
+# --------------------------------------------------------------------------- #
+
+# Keys we attempt to backfill, grouped by where build_enrichment reads them.
+# These are the SOURCE-SHAPED keys (what each provider returns), NOT the
+# build_enrichment output keys — we write them into verified_data so the
+# existing coalescing logic in build_enrichment picks the richest value.
+_BACKFILL_COUNT_KEYS = (
+    'cited_by_count', 'citationCount', 'is-referenced-by-count',
+    'referenced_works', 'referenceCount', 'references-count',
+)
+_BACKFILL_RICH_KEYS = (
+    'abstract', 'abstract_inverted_index', 'tldr', 'grants', 'funder', 'funders',
+)
+
+# Per-DOI TTL cache of merged-back fields. Mirrors _AUTHOR_PROFILE_CACHE in
+# backend/main.py: {doi: (monotonic_ts, {field: value})}. A 30-ref
+# bibliography that cites the same work twice fetches it once; a re-opened
+# check served within the TTL re-uses the cached fields with no network.
+_BACKFILL_CACHE: Dict[str, "tuple"] = {}
+_BACKFILL_TTL_SECONDS = 6 * 60 * 60  # 6 hours
+_BACKFILL_CACHE_LOCK = threading.Lock()
+
+# Concurrency cap so a big bibliography doesn't open dozens of simultaneous
+# outbound connections (and so a slow provider can't fan out into a stall).
+# Acquired around the *network* portion only; cache hits never touch it.
+_BACKFILL_TIMEOUT_SECONDS = 6.0
+_BACKFILL_MAX_CONCURRENCY = 6
+_BACKFILL_SEMAPHORE = threading.BoundedSemaphore(_BACKFILL_MAX_CONCURRENCY)
+
+
+def _is_empty_value(v: Any) -> bool:
+    """Treat None / '' (after strip) / [] / {} as "no signal" — same emptiness
+    test build_enrichment and _enrich_matched_paper use to decide a field is
+    missing. A real 0, a real False, or a non-empty container are NOT empty."""
+    if v is None:
+        return True
+    if isinstance(v, str):
+        return v.strip() == ''
+    if isinstance(v, (list, dict)):
+        return len(v) == 0
+    return False
+
+
+def _clean_doi(raw: Any) -> Optional[str]:
+    """Normalise to a bare lowercased DOI (10.xxxx/…). Strips resolver
+    prefixes and a trailing slash; rejects anything that isn't DOI-shaped so
+    we never issue a bogus /works/doi: lookup. Returns None on no real DOI."""
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    for prefix in ('https://doi.org/', 'http://doi.org/', 'https://dx.doi.org/',
+                   'http://dx.doi.org/', 'doi:'):
+        if s.lower().startswith(prefix):
+            s = s[len(prefix):]
+            break
+    s = s.strip().rstrip('/')
+    low = s.lower()
+    # DOI-shape guard: must start with the "10." registrant prefix and contain
+    # the '/' separator. Anything else is not a DOI we can resolve.
+    if not low.startswith('10.') or '/' not in low:
+        return None
+    return low
+
+
+def _canonical_doi_for_backfill(verified_data: Dict[str, Any],
+                                reference: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Resolve the canonical DOI to backfill against — winning payload first,
+    cited reference last. Mirrors the cleaning at enhanced_hybrid_checker.py."""
+    candidates = [
+        verified_data.get('doi'),
+        verified_data.get('DOI'),
+        (verified_data.get('ids') or {}).get('doi') if isinstance(verified_data.get('ids'), dict) else None,
+        (verified_data.get('externalIds') or {}).get('DOI') if isinstance(verified_data.get('externalIds'), dict) else None,
+        (reference or {}).get('doi'),
+    ]
+    for c in candidates:
+        cleaned = _clean_doi(c)
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _http_get_json(url: str, *, params: Optional[Dict[str, Any]] = None,
+                   headers: Optional[Dict[str, str]] = None,
+                   timeout: float = _BACKFILL_TIMEOUT_SECONDS) -> Optional[Dict[str, Any]]:
+    """GET → parsed JSON dict, with exactly ONE retry and a short timeout.
+    Returns None on any failure (network / non-200 / non-dict body) — the
+    caller soft-fails. Bounded by the module concurrency semaphore so a wide
+    bibliography can't fan out into a stall."""
+    try:
+        import requests  # local import: keeps module import pure-stdlib for the test harness
+    except Exception:  # pragma: no cover - requests is a hard dep in the app
+        return None
+    last_exc: Optional[Exception] = None
+    for attempt in range(2):  # 1 try + 1 retry
+        acquired = _BACKFILL_SEMAPHORE.acquire(timeout=timeout)
+        if not acquired:
+            return None
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+        except Exception as exc:  # network / timeout
+            last_exc = exc
+            resp = None
+        finally:
+            _BACKFILL_SEMAPHORE.release()
+        if resp is not None:
+            if resp.status_code == 200:
+                try:
+                    data = resp.json()
+                except ValueError as exc:
+                    last_exc = exc
+                    data = None
+                if isinstance(data, dict):
+                    return data
+                return None
+            # 404 / 410 are definitive "no such record" — don't retry.
+            if resp.status_code in (404, 410):
+                return None
+    if last_exc is not None:
+        logger.debug("backfill GET failed for %s: %s", url, last_exc)
+    return None
+
+
+def _fetch_openalex_by_doi(doi: str) -> Dict[str, Any]:
+    """OpenAlex /works/doi:{doi} → the source-shaped fields build_enrichment
+    reads: cited_by_count, referenced_works (length), abstract_inverted_index,
+    grants[]. Real values only; missing fields are simply omitted."""
+    data = _http_get_json(f"https://api.openalex.org/works/doi:{quote(doi, safe='')}")
+    if not isinstance(data, dict):
+        return {}
+    out: Dict[str, Any] = {}
+    for k in ('cited_by_count', 'referenced_works', 'abstract_inverted_index', 'grants'):
+        v = data.get(k)
+        if not _is_empty_value(v):
+            out[k] = v
+    return out
+
+
+def _fetch_crossref_by_doi(doi: str) -> Dict[str, Any]:
+    """Crossref /works/{doi} → is-referenced-by-count, references-count, JATS
+    abstract, funder[]. Crossref wraps the record in a `message` envelope."""
+    data = _http_get_json(
+        f"https://api.crossref.org/works/{quote(doi, safe='')}",
+        headers={'User-Agent': 'refchecker/enrichment-backfill (mailto:support@refchecker.app)'},
+    )
+    msg = (data or {}).get('message') if isinstance(data, dict) else None
+    if not isinstance(msg, dict):
+        return {}
+    out: Dict[str, Any] = {}
+    for k in ('is-referenced-by-count', 'references-count', 'abstract', 'funder'):
+        v = msg.get(k)
+        if not _is_empty_value(v):
+            out[k] = v
+    return out
+
+
+def _fetch_s2_by_doi(doi: str) -> Dict[str, Any]:
+    """Semantic Scholar /paper/DOI:{doi} → citationCount, referenceCount, tldr,
+    abstract. tldr comes back nested as {model, text}; build_enrichment already
+    accepts that shape."""
+    data = _http_get_json(
+        f"https://api.semanticscholar.org/graph/v1/paper/DOI:{quote(doi, safe='')}",
+        params={'fields': 'citationCount,referenceCount,tldr,abstract'},
+    )
+    if not isinstance(data, dict):
+        return {}
+    out: Dict[str, Any] = {}
+    for k in ('citationCount', 'referenceCount', 'tldr', 'abstract'):
+        v = data.get(k)
+        if not _is_empty_value(v):
+            out[k] = v
+    return out
+
+
+def _gather_backfill_fields(doi: str) -> Dict[str, Any]:
+    """Fetch the union of missing-able fields for a DOI across all three
+    sources, cached per-DOI with a TTL. Soft-fails per source. The merged dict
+    keeps the FIRST real value seen for each source-shaped key (OpenAlex →
+    Crossref → S2 order), but build_enrichment's own coalescing picks the
+    richest value across whatever lands, so source order is not load-bearing
+    for the displayed number."""
+    now = time.monotonic()
+    with _BACKFILL_CACHE_LOCK:
+        cached = _BACKFILL_CACHE.get(doi)
+        if cached and (now - cached[0]) < _BACKFILL_TTL_SECONDS:
+            return dict(cached[1])
+
+    merged: Dict[str, Any] = {}
+    for fetcher in (_fetch_openalex_by_doi, _fetch_crossref_by_doi, _fetch_s2_by_doi):
+        try:
+            got = fetcher(doi)
+        except Exception as exc:  # belt-and-braces: a fetcher must never raise
+            logger.debug("backfill fetcher %s failed for %s: %s", getattr(fetcher, '__name__', '?'), doi, exc)
+            got = {}
+        for k, v in (got or {}).items():
+            if k not in merged and not _is_empty_value(v):
+                merged[k] = v
+
+    with _BACKFILL_CACHE_LOCK:
+        _BACKFILL_CACHE[doi] = (now, dict(merged))
+    return merged
+
+
+def _wants_backfill(verified_data: Dict[str, Any]) -> bool:
+    """True only when at least one backfill-able display signal is genuinely
+    missing — so a payload that already carries counts + abstract + tldr +
+    funding makes ZERO network calls. Keeps a rich-source winner free."""
+    has_count = any(not _is_empty_value(verified_data.get(k)) for k in _BACKFILL_COUNT_KEYS)
+    has_rich = any(not _is_empty_value(verified_data.get(k)) for k in _BACKFILL_RICH_KEYS)
+    # Want backfill if EITHER the count family OR the rich family is empty.
+    return (not has_count) or (not has_rich)
+
+
+def backfill_enrichment(verified_data: Optional[Dict[str, Any]],
+                        reference: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Backfill missing count / abstract / tldr / funding signals into
+    `verified_data` by DOI from OpenAlex / Crossref / Semantic Scholar, then
+    return the (mutated, for caller convenience) dict.
+
+    Never overwrites a real value, never fabricates, soft-fails on any error,
+    and is bounded (per-DOI TTL cache + 1 retry + short timeout + concurrency
+    cap). Call this right before `build_enrichment` so the projection surfaces
+    the enriched values with no frontend change.
+
+    Returns the same dict it was given (mutated in place) so callers can write
+    `verified_data = backfill_enrichment(verified_data, reference)`. Returns a
+    non-dict input unchanged.
+    """
+    if not isinstance(verified_data, dict):
+        return verified_data  # type: ignore[return-value]
+
+    try:
+        # Skip entirely when the winning payload is already rich — no DOI
+        # lookup, no network. The common S2/OpenAlex-winner case costs nothing.
+        if not _wants_backfill(verified_data):
+            return verified_data
+
+        doi = _canonical_doi_for_backfill(verified_data, reference)
+        if not doi:
+            # No DOI to resolve against — nothing we can honestly backfill.
+            return verified_data
+
+        fields = _gather_backfill_fields(doi)
+        for key, value in fields.items():
+            # NEVER overwrite a real existing value — merge only into keys the
+            # payload lacks or whose value is empty. Mirrors _enrich_matched_paper.
+            if _is_empty_value(value):
+                continue
+            if _is_empty_value(verified_data.get(key)):
+                verified_data[key] = value
+    except Exception as exc:  # soft-fail: a display nicety must never break verification
+        logger.debug("backfill_enrichment soft-failed: %s", exc)
+
+    return verified_data

--- a/src/refchecker/utils/reference_fulltext.py
+++ b/src/refchecker/utils/reference_fulltext.py
@@ -1,0 +1,331 @@
+"""R43 — per-reference full-text retrieval for grounded chat.
+
+Resolve a cited reference's open-access PDF (arXiv → OpenAlex ``best_oa_location``
+/ Unpaywall → its own ``oa_pdf_url``), download it, and extract the real body
+text with PyMuPDF so the per-reference Chat & Summarize assistant can answer
+from the *document* instead of only the TL;DR / abstract metadata.
+
+Honesty (by construction):
+  * Only REAL fetched text is returned. If no OA PDF resolves, or the download
+    / extraction fails, we return ``(None, 'tldr')`` and the caller keeps the
+    existing TL;DR-only disclaimer verbatim — nothing is fabricated.
+  * The grounding source is reported explicitly: ``'pdf'`` when real full text
+    was extracted, ``'tldr'`` otherwise.
+
+Operational safety:
+  * Cached per identity (arXiv id / DOI / title) with a TTL so re-opening the
+    same reference chat — or two refs that resolve to the same work — fetches
+    once.
+  * Soft-fail everywhere: any network / parse error returns the TL;DR fallback,
+    never raises into the request path.
+  * Bounded concurrency: a single shared semaphore caps simultaneous outbound
+    downloads so a burst of opened chats can't fan out into a stall.
+
+Top-level imports stay light (stdlib + the already-present ``url_utils`` /
+``doi_utils``); ``fitz`` (PyMuPDF) and ``requests`` are imported lazily inside
+the functions that need them so this module imports cleanly in the deps-free
+test harness.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import quote
+
+logger = logging.getLogger(__name__)
+
+# Below this many extracted chars we don't trust the PDF as real full text
+# (a cover page, a paywall stub, or a failed extraction). Treat as a miss and
+# fall back to the TL;DR rather than ground on a near-empty document.
+_MIN_FULLTEXT_CHARS = 1500
+
+# Cap the returned text so a 60-page paper can't blow the chat context budget.
+# In ref-mode the fetched full text rides into the chat as a *message-history*
+# turn (``ArticleAssistant.groundingPreamble``), NOT through the ``grounding``
+# parameter — so the backend's only length guard,
+# ``article_chat.MAX_GROUNDING_CHARS`` (applied solely in
+# ``_build_document_block`` to the host-paper grounding), never truncates it.
+# This cap is therefore the REAL bound on the per-reference payload, kept in
+# lockstep with that chat grounding budget so the reference body + the always-
+# injected host-paper grounding stay within the model context window (and don't
+# silently inflate cost). It also bounds the cache entry size.
+_MAX_FULLTEXT_CHARS = 48_000  # == backend.article_chat.MAX_GROUNDING_CHARS
+
+# Per-identity TTL cache: {identity_key: (monotonic_ts, full_text_or_None)}.
+# A ``None`` value is cached too (negative cache) so a known-miss reference
+# isn't re-fetched on every chat open within the TTL.
+_FULLTEXT_CACHE: Dict[str, Tuple[float, Optional[str]]] = {}
+_FULLTEXT_TTL_SECONDS = 12 * 60 * 60  # 12 hours
+_FULLTEXT_CACHE_LOCK = threading.Lock()
+
+# Bound simultaneous OA-PDF downloads. Acquired around the network portion
+# only; cache hits never touch it.
+_FULLTEXT_MAX_CONCURRENCY = 4
+_FULLTEXT_SEMAPHORE = threading.BoundedSemaphore(_FULLTEXT_MAX_CONCURRENCY)
+_FULLTEXT_TIMEOUT_SECONDS = 30.0
+
+# Source-resolution metadata HTTP timeout (OpenAlex / Unpaywall JSON).
+_RESOLVE_TIMEOUT_SECONDS = 8.0
+
+# Unpaywall requires a contact email in the query string. Matches the
+# contact used by the Crossref backfill fetcher.
+_UNPAYWALL_EMAIL = "support@refchecker.app"
+
+
+def _clean_doi(raw: Any) -> Optional[str]:
+    """Normalise to a bare lowercased DOI (10.xxxx/…) or None.
+
+    Reuses the same resolver-prefix stripping + DOI-shape guard as the
+    enrichment backfill so we never issue a bogus lookup.
+    """
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    for prefix in (
+        "https://doi.org/", "http://doi.org/",
+        "https://dx.doi.org/", "http://dx.doi.org/", "doi:",
+    ):
+        if s.lower().startswith(prefix):
+            s = s[len(prefix):]
+            break
+    s = s.strip().rstrip("/")
+    low = s.lower()
+    if not low.startswith("10.") or "/" not in low:
+        return None
+    return low
+
+
+def _identity_key(reference: Dict[str, Any]) -> Optional[str]:
+    """A stable cache key for a reference, in resolution priority order.
+
+    arXiv id > DOI > lowercased title. Returns None when the reference has no
+    usable identity (so we won't attempt retrieval or cache a useless key).
+    """
+    arxiv_id = (reference.get("arxiv_id") or "").strip()
+    if arxiv_id:
+        return f"arxiv:{arxiv_id.lower()}"
+    doi = _clean_doi(reference.get("doi") or reference.get("verified_doi"))
+    if doi:
+        return f"doi:{doi}"
+    title = (reference.get("title") or "").strip().lower()
+    if title:
+        return f"title:{title}"
+    return None
+
+
+def _http_get_json(url: str, *, params: Optional[Dict[str, Any]] = None,
+                   timeout: float = _RESOLVE_TIMEOUT_SECONDS) -> Optional[Dict[str, Any]]:
+    """GET → parsed JSON dict; None on any failure (soft-fail, no retry)."""
+    try:
+        import requests
+    except Exception:  # pragma: no cover - requests is a hard app dep
+        return None
+    try:
+        resp = requests.get(url, params=params, timeout=timeout)
+    except Exception as exc:
+        logger.debug("reference-fulltext resolve GET failed for %s: %s", url, exc)
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _arxiv_pdf_url(reference: Dict[str, Any]) -> Optional[str]:
+    """Build the arXiv PDF URL when the reference carries an arXiv id."""
+    arxiv_id = (reference.get("arxiv_id") or "").strip()
+    if not arxiv_id:
+        return None
+    try:
+        from refchecker.utils.url_utils import construct_arxiv_url
+        return construct_arxiv_url(arxiv_id, url_type="pdf")
+    except Exception:
+        return f"https://arxiv.org/pdf/{arxiv_id}.pdf"
+
+
+def _oa_pdf_url_from_openalex(doi: str) -> Optional[str]:
+    """OpenAlex /works/doi:{doi} → best_oa_location.pdf_url (or oa url).
+
+    OpenAlex exposes the curated open-access copy under ``best_oa_location``;
+    we prefer its ``pdf_url`` and fall back to its landing-page ``url`` only
+    when it points at a PDF.
+    """
+    data = _http_get_json(f"https://api.openalex.org/works/doi:{quote(doi, safe='')}")
+    if not isinstance(data, dict):
+        return None
+    for loc_key in ("best_oa_location", "primary_location"):
+        loc = data.get(loc_key)
+        if isinstance(loc, dict):
+            pdf = loc.get("pdf_url")
+            if isinstance(pdf, str) and pdf.strip():
+                return pdf.strip()
+    # open_access.oa_url is a landing page; only trust it when it's a PDF link.
+    oa = data.get("open_access")
+    if isinstance(oa, dict):
+        oa_url = oa.get("oa_url")
+        if isinstance(oa_url, str) and oa_url.lower().endswith(".pdf"):
+            return oa_url.strip()
+    return None
+
+
+def _oa_pdf_url_from_unpaywall(doi: str) -> Optional[str]:
+    """Unpaywall /v2/{doi} → best_oa_location.url_for_pdf."""
+    data = _http_get_json(
+        f"https://api.unpaywall.org/v2/{quote(doi, safe='')}",
+        params={"email": _UNPAYWALL_EMAIL},
+    )
+    if not isinstance(data, dict):
+        return None
+    best = data.get("best_oa_location")
+    if isinstance(best, dict):
+        for k in ("url_for_pdf", "url"):
+            v = best.get(k)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+    # Fall back to scanning all OA locations for a direct PDF.
+    for loc in (data.get("oa_locations") or []):
+        if isinstance(loc, dict):
+            v = loc.get("url_for_pdf")
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+    return None
+
+
+def _resolve_oa_pdf_url(reference: Dict[str, Any]) -> Optional[str]:
+    """Resolve a downloadable OA PDF URL for the reference, or None.
+
+    Priority: a PDF URL we already hold (enrichment.oa_pdf_url) → arXiv (no
+    network needed) → OpenAlex best_oa_location → Unpaywall. Each step
+    soft-fails; the first real URL wins.
+    """
+    # 0) Already-resolved OA PDF carried on the enrichment payload.
+    enrichment = reference.get("enrichment") or {}
+    if isinstance(enrichment, dict):
+        held = enrichment.get("oa_pdf_url")
+        if isinstance(held, str) and held.strip():
+            return held.strip()
+        links = enrichment.get("links")
+        if isinstance(links, dict):
+            held = links.get("oa_pdf")
+            if isinstance(held, str) and held.strip():
+                return held.strip()
+
+    # 1) arXiv — deterministic URL, no metadata round-trip.
+    arxiv_url = _arxiv_pdf_url(reference)
+    if arxiv_url:
+        return arxiv_url
+
+    # 2/3) DOI → OpenAlex best_oa_location, else Unpaywall.
+    doi = _clean_doi(reference.get("doi") or reference.get("verified_doi"))
+    if doi:
+        for resolver in (_oa_pdf_url_from_openalex, _oa_pdf_url_from_unpaywall):
+            try:
+                url = resolver(doi)
+            except Exception as exc:
+                logger.debug("OA resolve %s failed for %s: %s",
+                             getattr(resolver, "__name__", "?"), doi, exc)
+                url = None
+            if url:
+                return url
+    return None
+
+
+def _extract_pdf_text(pdf_bytes: bytes) -> str:
+    """Extract body text from PDF bytes with PyMuPDF (fitz). '' on failure."""
+    try:
+        import fitz  # PyMuPDF
+    except Exception as exc:  # pragma: no cover - fitz is bundled in the app
+        logger.debug("PyMuPDF unavailable for reference full text: %s", exc)
+        return ""
+    try:
+        parts = []
+        with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+            for page in doc:
+                parts.append(page.get_text("text") or "")
+        return "\n".join(parts).strip()
+    except Exception as exc:
+        logger.debug("PyMuPDF extraction failed for reference PDF: %s", exc)
+        return ""
+
+
+def _download_and_extract(url: str) -> Optional[str]:
+    """Download the OA PDF and extract its text. None on any failure.
+
+    Bounded by the module concurrency semaphore around the network +
+    extraction work so a burst of opened chats can't fan out into a stall.
+    """
+    acquired = _FULLTEXT_SEMAPHORE.acquire(timeout=_FULLTEXT_TIMEOUT_SECONDS)
+    if not acquired:
+        logger.debug("reference-fulltext concurrency cap hit; skipping %s", url)
+        return None
+    try:
+        from refchecker.utils.url_utils import download_pdf_bytes
+        # Keep the per-reference retrieval snappy: short-ish timeout and a
+        # bounded retry budget so a slow mirror can't wedge the chat open.
+        data = download_pdf_bytes(url, timeout=30, max_retry_seconds=45.0)
+    except Exception as exc:
+        logger.debug("reference-fulltext download failed for %s: %s", url, exc)
+        return None
+    finally:
+        _FULLTEXT_SEMAPHORE.release()
+
+    if not data:
+        return None
+    text = _extract_pdf_text(data)
+    if len(text) < _MIN_FULLTEXT_CHARS:
+        return None
+    if len(text) > _MAX_FULLTEXT_CHARS:
+        text = text[:_MAX_FULLTEXT_CHARS]
+    return text
+
+
+def get_reference_fulltext(reference: Dict[str, Any]) -> Tuple[Optional[str], str]:
+    """Retrieve a reference's REAL OA full text for grounded chat.
+
+    Returns ``(full_text, 'pdf')`` when a genuine OA PDF was fetched and
+    extracted, else ``(None, 'tldr')`` — the caller then keeps the TL;DR /
+    metadata grounding and its existing disclaimer verbatim. Never raises:
+    every failure mode soft-fails to the TL;DR fallback.
+
+    Cached per identity (arXiv id / DOI / title) with a TTL, including a
+    negative cache for known misses.
+    """
+    if not isinstance(reference, dict):
+        return None, "tldr"
+    key = _identity_key(reference)
+    if not key:
+        return None, "tldr"
+
+    now = time.monotonic()
+    with _FULLTEXT_CACHE_LOCK:
+        cached = _FULLTEXT_CACHE.get(key)
+        if cached and (now - cached[0]) < _FULLTEXT_TTL_SECONDS:
+            text = cached[1]
+            return (text, "pdf") if text else (None, "tldr")
+
+    text: Optional[str] = None
+    try:
+        url = _resolve_oa_pdf_url(reference)
+        if url:
+            text = _download_and_extract(url)
+    except Exception as exc:  # belt-and-braces: retrieval must never raise
+        logger.debug("reference-fulltext retrieval errored for %s: %s", key, exc)
+        text = None
+
+    with _FULLTEXT_CACHE_LOCK:
+        _FULLTEXT_CACHE[key] = (now, text)
+
+    return (text, "pdf") if text else (None, "tldr")
+
+
+def clear_cache() -> None:
+    """Drop the full-text cache (used by tests to isolate runs)."""
+    with _FULLTEXT_CACHE_LOCK:
+        _FULLTEXT_CACHE.clear()

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1,0 +1,336 @@
+"""Unit tests for reference enrichment (build_enrichment).
+
+Loaded directly from the source file so the suite runs without the heavy
+``refchecker`` package __init__ (which pulls tqdm etc.) — the module itself is
+pure stdlib.
+"""
+
+import importlib.util
+import pathlib
+
+_ENRICH_PATH = pathlib.Path(__file__).resolve().parents[2] / "src" / "refchecker" / "utils" / "enrichment.py"
+_spec = importlib.util.spec_from_file_location("rc_enrichment_under_test", _ENRICH_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+build_enrichment = _mod.build_enrichment
+
+
+# --------------------------------------------------------------------------- #
+# New article-intelligence fields (abstract / tldr / oa_pdf_url / is_preprint)  #
+# --------------------------------------------------------------------------- #
+
+def test_build_enrichment_emits_tldr_from_s2():
+    e = build_enrichment({"tldr": {"text": "Key finding X"}})
+    assert e["tldr"] == "Key finding X"
+    # Absent/null tldr -> the KEY is absent (not '' / None).
+    assert "tldr" not in build_enrichment({"title": "x"})
+    assert "tldr" not in build_enrichment({"tldr": {"text": None}})
+
+
+def test_build_enrichment_abstract_prefers_s2_string_then_reconstructs_openalex():
+    # S2/Crossref plain string is used verbatim.
+    assert build_enrichment({"abstract": "Plain abstract."})["abstract"] == "Plain abstract."
+    # When absent, OpenAlex inverted index is reconstructed in position order.
+    inv = {"Deep": [0], "learning": [1], "works": [2]}
+    assert build_enrichment({"abstract_inverted_index": inv})["abstract"] == "Deep learning works"
+    # Duplicate positions / gaps don't scramble (word repeated at each index).
+    inv2 = {"the": [0, 2], "cat": [1], "sat": [3]}
+    assert build_enrichment({"abstract_inverted_index": inv2})["abstract"] == "the cat the sat"
+    # No abstract anywhere -> key absent.
+    assert "abstract" not in build_enrichment({"title": "x"})
+
+
+def test_build_enrichment_crossref_abstract_strips_jats():
+    e = build_enrichment({"abstract": "<jats:p>Hello <jats:italic>world</jats:italic></jats:p>"})
+    assert e["abstract"] == "Hello world"
+
+
+def test_build_enrichment_oa_pdf_url_waterfall():
+    # S2 wins.
+    e = build_enrichment({
+        "openAccessPdf": {"url": "https://s2.example/p.pdf"},
+        "open_access": {"oa_url": "https://oa.example/p"},
+    })
+    assert e["oa_pdf_url"] == "https://s2.example/p.pdf"
+    assert e["links"]["oa_pdf"] == "https://s2.example/p.pdf"
+    # OpenAlex oa_url next.
+    assert build_enrichment({"open_access": {"oa_url": "https://oa.example/p"}})["oa_pdf_url"] == "https://oa.example/p"
+    # primary_location.pdf_url last.
+    assert build_enrichment({"primary_location": {"pdf_url": "https://pl.example/p.pdf"}})["oa_pdf_url"] == "https://pl.example/p.pdf"
+    # None present -> key absent.
+    assert "oa_pdf_url" not in build_enrichment({"title": "x"})
+
+
+def test_build_enrichment_is_preprint():
+    assert build_enrichment({"type": "preprint"}).get("is_preprint") is True
+    assert build_enrichment({"type": "posted-content"}).get("is_preprint") is True
+    # Real journal article -> key absent (absence != False).
+    assert "is_preprint" not in build_enrichment({"type": "journal-article"})
+
+
+def test_build_enrichment_empty_input_returns_empty_dict():
+    assert build_enrichment({}) == {}
+    assert build_enrichment(None) == {}
+    assert build_enrichment("not a dict") == {}
+
+
+# --------------------------------------------------------------------------- #
+# Existing normalized fields keep working (regression guard for the widening)   #
+# --------------------------------------------------------------------------- #
+
+def test_build_enrichment_existing_counts_still_normalized():
+    e = build_enrichment({"citationCount": 65, "referenceCount": 30, "type": "journal-article"})
+    assert e["cited_by_count"] == 65
+    assert e["reference_count"] == 30
+    assert e["publication_type"] == "journal-article"
+
+
+def test_build_enrichment_funders_from_grants():
+    e = build_enrichment({"grants": [{"funder_display_name": "NIH"}, {"funder_display_name": "NSF"}]})
+    assert e["has_funding"] is True
+    assert e["funders"] == ["NIH", "NSF"]
+
+
+def test_build_enrichment_funders_from_crossref_s2_funders_list():
+    # Crossref/S2-shaped `funder[]`/`funders[]` (name key, or plain strings).
+    e = build_enrichment({"funder": [{"name": "Wellcome Trust"}, {"name": "ERC"}]})
+    assert e["has_funding"] is True
+    assert e["funders"] == ["Wellcome Trust", "ERC"]
+    e2 = build_enrichment({"funders": ["DFG", "ANR"]})
+    assert e2["funders"] == ["DFG", "ANR"]
+    # No funder named anywhere -> keys absent (absence != "no funding").
+    assert "has_funding" not in build_enrichment({"title": "x"})
+
+
+# --------------------------------------------------------------------------- #
+# Regression: a full Semantic-Scholar-shaped verified_data (exactly what the    #
+# S2 checker now returns once a matched-but-sparse paper is topped up from the  #
+# /paper/{paperId} record) yields abstract / tldr / cited_by_count /            #
+# reference_count on the reference card. This is the bug the fix targets:       #
+# previously only externalIds survived into verified_data, so the card showed   #
+# the link chips (PMID/LibKey/WorldCat) but no Abstract / Claim / counts.       #
+# --------------------------------------------------------------------------- #
+
+def test_build_enrichment_full_s2_shaped_payload_yields_rich_fields():
+    s2_verified_data = {
+        "paperId": "abc123def456",
+        "title": "Attention Is All You Need",
+        "abstract": "The dominant sequence transduction models are based on complex recurrent or convolutional neural networks.",
+        "tldr": {"model": "tldr@v2.0.0", "text": "Introduces the Transformer, a model based solely on attention."},
+        "citationCount": 95000,
+        "referenceCount": 38,
+        "year": 2017,
+        "venue": "NeurIPS",
+        "publicationTypes": ["JournalArticle", "Conference"],
+        "publicationDate": "2017-06-12",
+        "fieldsOfStudy": ["Computer Science"],
+        "externalIds": {
+            "DOI": "10.5555/3295222.3295349",
+            "ArXiv": "1706.03762",
+            "PubMed": "12345678",
+            "MAG": "2963403868",
+        },
+        "openAccessPdf": {"url": "https://arxiv.org/pdf/1706.03762.pdf"},
+        "isOpenAccess": True,
+        "_matched_database": "Semantic Scholar",
+    }
+    e = build_enrichment(s2_verified_data)
+
+    # The fields that were silently dropped before the fix.
+    assert e["abstract"].startswith("The dominant sequence transduction models")
+    assert e["tldr"] == "Introduces the Transformer, a model based solely on attention."
+    assert e["cited_by_count"] == 95000
+    assert e["reference_count"] == 38
+
+    # And the link IDs that always worked still do (regression guard).
+    assert e["pubmed_id"] == "12345678"
+    assert e["mag_id"] == "2963403868"
+    assert e["links"]["doi"] == "10.5555/3295222.3295349"
+    assert e["source_label"] == "Semantic Scholar"
+    # Field-of-study + OA PDF surface from the S2 shape too.
+    assert e["fields_of_study"] == ["Computer Science"]
+    assert e["oa_pdf_url"] == "https://arxiv.org/pdf/1706.03762.pdf"
+
+
+def test_build_enrichment_tldr_accepts_plain_string():
+    # Flattened S2 tldr (plain string) is accepted, same as the nested dict.
+    assert build_enrichment({"tldr": "A flat claim string."})["tldr"] == "A flat claim string."
+    # Nested form still works.
+    assert build_enrichment({"tldr": {"text": "Nested claim."}})["tldr"] == "Nested claim."
+    # Empty/blank string -> key absent.
+    assert "tldr" not in build_enrichment({"tldr": "   "})
+
+
+# --------------------------------------------------------------------------- #
+# Cross-source backfill (R21 / R22) — backfill_enrichment                       #
+#                                                                             #
+# All tests are network-free: the per-DOI gather is stubbed, so no real HTTP   #
+# is issued. They lock the never-overwrite / never-fabricate / soft-fail       #
+# contract and the "skip when already rich" short-circuit.                     #
+# --------------------------------------------------------------------------- #
+
+import pytest  # noqa: E402
+
+backfill_enrichment = _mod.backfill_enrichment
+
+
+@pytest.fixture(autouse=True)
+def _clear_backfill_cache():
+    """Each backfill test starts with an empty per-DOI cache."""
+    _mod._BACKFILL_CACHE.clear()
+    yield
+    _mod._BACKFILL_CACHE.clear()
+
+
+def _stub_gather(monkeypatch, fields):
+    """Make _gather_backfill_fields return `fields` for any DOI without
+    touching the network (so no real OpenAlex/Crossref/S2 call fires)."""
+    calls = {"n": 0}
+
+    def fake_gather(doi):
+        calls["n"] += 1
+        return dict(fields)
+
+    monkeypatch.setattr(_mod, "_gather_backfill_fields", fake_gather)
+    return calls
+
+
+def test_backfill_non_dict_input_returned_unchanged(monkeypatch):
+    _stub_gather(monkeypatch, {"cited_by_count": 5})
+    assert backfill_enrichment(None) is None
+    assert backfill_enrichment("nope") == "nope"
+
+
+def test_backfill_merges_only_when_missing(monkeypatch):
+    # A non-S2 winner (DBLP-shaped) with a DOI but no counts/abstract/tldr.
+    vd = {"doi": "10.1109/ABC.2021.12345", "source": "DBLP", "title": "Paper"}
+    _stub_gather(monkeypatch, {
+        "cited_by_count": 182,
+        "referenced_works": ["W1", "W2", "W3"],
+        "abstract": "A real abstract.",
+        "tldr": {"text": "A real claim."},
+        "grants": [{"funder_display_name": "NIH"}],
+    })
+    out = backfill_enrichment(vd, {"doi": "10.1109/ABC.2021.12345"})
+    # Mutated in place AND returned (caller convenience).
+    assert out is vd
+    e = build_enrichment(out)
+    assert e["cited_by_count"] == 182
+    assert e["reference_count"] == 3
+    assert e["abstract"] == "A real abstract."
+    assert e["tldr"] == "A real claim."
+    assert e["has_funding"] is True and e["funders"] == ["NIH"]
+
+
+def test_backfill_never_overwrites_existing_real_values(monkeypatch):
+    # Winner carries a real count but NO rich field (so backfill DOES run — the
+    # rich family is empty). The backfill source returns a DIFFERENT count plus
+    # a genuinely-missing referenceCount + abstract: the existing real count
+    # must survive untouched, the missing fields must be filled.
+    vd = {
+        "doi": "10.1/x",
+        "cited_by_count": 10,   # real existing count — must NOT be overwritten
+    }
+    _stub_gather(monkeypatch, {
+        "cited_by_count": 999,            # different value — must be ignored
+        "abstract": "Backfilled abstract.",  # missing → should be added
+        "referenceCount": 42,             # missing → should be added
+    })
+    backfill_enrichment(vd)
+    assert vd["cited_by_count"] == 10               # not overwritten
+    assert vd["abstract"] == "Backfilled abstract."  # missing → backfilled
+    assert vd["referenceCount"] == 42              # missing → backfilled
+    e = build_enrichment(vd)
+    assert e["cited_by_count"] == 10
+    assert e["reference_count"] == 42
+    assert e["abstract"] == "Backfilled abstract."
+
+
+def test_backfill_does_not_overwrite_existing_rich_when_count_missing(monkeypatch):
+    # Symmetric guard: a winner with a real abstract/tldr but no count. Backfill
+    # runs (count family empty) and must NOT clobber the existing rich values.
+    vd = {
+        "doi": "10.1/y",
+        "abstract": "Original abstract.",
+        "tldr": "Original claim.",
+    }
+    _stub_gather(monkeypatch, {
+        "cited_by_count": 77,                 # missing → should be added
+        "abstract": "Backfilled abstract.",   # existing → must be ignored
+        "tldr": {"text": "Backfilled claim."},  # existing → must be ignored
+    })
+    backfill_enrichment(vd)
+    assert vd["cited_by_count"] == 77             # missing → backfilled
+    assert vd["abstract"] == "Original abstract."  # not overwritten
+    assert vd["tldr"] == "Original claim."        # not overwritten
+
+
+def test_backfill_skips_network_when_already_rich(monkeypatch):
+    # Payload already has BOTH a count AND a rich field → no DOI lookup at all.
+    calls = _stub_gather(monkeypatch, {"cited_by_count": 5})
+    vd = {"doi": "10.1/x", "citationCount": 7, "abstract": "Has one."}
+    backfill_enrichment(vd)
+    assert calls["n"] == 0          # gather never called
+    assert vd["citationCount"] == 7  # untouched
+
+
+def test_backfill_no_doi_does_nothing(monkeypatch):
+    calls = _stub_gather(monkeypatch, {"cited_by_count": 5})
+    vd = {"source": "DBLP", "title": "No DOI here"}
+    backfill_enrichment(vd, {"title": "No DOI here"})
+    assert calls["n"] == 0
+    assert "cited_by_count" not in vd
+
+
+def test_backfill_resolves_doi_from_reference_when_winner_lacks_it(monkeypatch):
+    calls = _stub_gather(monkeypatch, {"cited_by_count": 11})
+    vd = {"source": "ACL", "title": "Paper"}  # no DOI in the winner
+    backfill_enrichment(vd, {"doi": "https://doi.org/10.18653/v1/2020.acl-main.1"})
+    assert calls["n"] == 1
+    assert vd["cited_by_count"] == 11
+
+
+def test_backfill_soft_fails_on_gather_exception(monkeypatch):
+    def boom(doi):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(_mod, "_gather_backfill_fields", boom)
+    vd = {"doi": "10.1/x", "source": "DBLP", "title": "Paper"}
+    # Must NOT raise — soft-fail — and must leave the payload intact.
+    out = backfill_enrichment(vd)
+    assert out is vd
+    assert "cited_by_count" not in vd
+
+
+def test_backfill_clean_doi_rejects_non_doi():
+    # Guard: a bogus / non-DOI-shaped string never resolves to a lookup target.
+    assert _mod._clean_doi("not-a-doi") is None
+    assert _mod._clean_doi("12345") is None
+    assert _mod._clean_doi("") is None
+    assert _mod._clean_doi(None) is None
+    # Real DOIs normalise to the bare lowercased form regardless of resolver prefix.
+    assert _mod._clean_doi("https://doi.org/10.1109/ABC.2021") == "10.1109/abc.2021"
+    assert _mod._clean_doi("doi:10.5555/3295222.3295349") == "10.5555/3295222.3295349"
+
+
+def test_backfill_per_doi_cache_dedupes(monkeypatch):
+    # _gather_backfill_fields caches per DOI; calling backfill twice for the
+    # same DOI hits the underlying fetchers once. We stub at the fetcher layer
+    # so the real cache logic in _gather_backfill_fields is exercised.
+    fetch_calls = {"n": 0}
+
+    def fake_openalex(doi):
+        fetch_calls["n"] += 1
+        return {"cited_by_count": 50}
+
+    monkeypatch.setattr(_mod, "_fetch_openalex_by_doi", fake_openalex)
+    monkeypatch.setattr(_mod, "_fetch_crossref_by_doi", lambda doi: {})
+    monkeypatch.setattr(_mod, "_fetch_s2_by_doi", lambda doi: {})
+
+    vd1 = {"doi": "10.1/same", "source": "DBLP", "title": "A"}
+    vd2 = {"doi": "10.1/same", "source": "DBLP", "title": "B"}
+    backfill_enrichment(vd1)
+    backfill_enrichment(vd2)
+    assert vd1["cited_by_count"] == 50
+    assert vd2["cited_by_count"] == 50
+    assert fetch_calls["n"] == 1  # second call served from the per-DOI cache

--- a/tests/unit/test_reference_fulltext.py
+++ b/tests/unit/test_reference_fulltext.py
@@ -1,0 +1,184 @@
+"""R43 — per-reference full-text retrieval for grounded chat.
+
+Exercises ``refchecker.utils.reference_fulltext`` with the network + PyMuPDF
+layers monkeypatched (no real downloads / no fitz needed) and asserts the
+honesty contract:
+
+  * OA hit  → ``(full_text, 'pdf')`` — chat grounds in the fetched document.
+  * OA miss → ``(None, 'tldr')``     — the FE keeps the TL;DR disclaimer.
+  * Soft-fail: a download / extraction / resolver error never raises; it falls
+    back to ``(None, 'tldr')``.
+  * Cached per identity (arXiv id / DOI / title) with a negative cache for
+    misses, so a re-opened chat doesn't re-fetch.
+"""
+
+import pytest
+
+from refchecker.utils import reference_fulltext as rf
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    rf.clear_cache()
+    yield
+    rf.clear_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Identity / DOI helpers                                                       #
+# --------------------------------------------------------------------------- #
+
+def test_identity_key_priority_and_normalization():
+    # arXiv wins over DOI/title.
+    assert rf._identity_key({"arxiv_id": "2310.06825", "doi": "10.1/x", "title": "T"}) == "arxiv:2310.06825"
+    # DOI is normalised (resolver prefix stripped, lowercased).
+    assert rf._identity_key({"doi": "https://doi.org/10.1145/AbC"}) == "doi:10.1145/abc"
+    # Title fallback is lowercased.
+    assert rf._identity_key({"title": "Attention Is All You Need"}) == "title:attention is all you need"
+    # No real identity → None (caller won't attempt retrieval).
+    assert rf._identity_key({}) is None
+    assert rf._identity_key({"doi": "not-a-doi"}) is None
+
+
+def test_clean_doi_rejects_non_doi():
+    assert rf._clean_doi("10.1145/3292500") == "10.1145/3292500"
+    assert rf._clean_doi("doi:10.5555/Foo/Bar") == "10.5555/foo/bar"
+    assert rf._clean_doi("https://example.com/x") is None
+    assert rf._clean_doi(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# OA hit → full-text grounding                                                 #
+# --------------------------------------------------------------------------- #
+
+def test_oa_hit_returns_full_text_and_pdf_source(monkeypatch):
+    full = "F" * (rf._MIN_FULLTEXT_CHARS + 100)
+
+    def fake_resolve(reference):
+        return "https://arxiv.org/pdf/2310.06825.pdf"
+
+    def fake_dl(url, **kwargs):
+        return b"%PDF-fake-bytes"
+
+    def fake_extract(data):
+        return full
+
+    monkeypatch.setattr(rf, "_resolve_oa_pdf_url", fake_resolve)
+    # Patch the download + extraction at the seam so no network / fitz needed.
+    monkeypatch.setattr("refchecker.utils.url_utils.download_pdf_bytes", fake_dl)
+    monkeypatch.setattr(rf, "_extract_pdf_text", fake_extract)
+
+    text, source = rf.get_reference_fulltext({"arxiv_id": "2310.06825"})
+    assert source == "pdf"
+    assert text == full
+
+
+def test_fulltext_capped_to_chat_grounding_budget(monkeypatch):
+    # In ref-mode the fetched full text rides into the chat as a message-history
+    # turn, so the backend's MAX_GROUNDING_CHARS guard never truncates it — this
+    # cap is the REAL bound. It must stay in lockstep with the chat budget so an
+    # oversized reference body can't overflow the model context / inflate cost.
+    huge = "F" * (rf._MAX_FULLTEXT_CHARS * 3)
+
+    monkeypatch.setattr(rf, "_resolve_oa_pdf_url", lambda r: "https://host/p.pdf")
+    monkeypatch.setattr("refchecker.utils.url_utils.download_pdf_bytes", lambda url, **k: b"%PDF")
+    monkeypatch.setattr(rf, "_extract_pdf_text", lambda data: huge)
+
+    text, source = rf.get_reference_fulltext({"arxiv_id": "2310.06825"})
+    assert source == "pdf"
+    assert text is not None and len(text) == rf._MAX_FULLTEXT_CHARS
+
+    # The cap must match the backend chat grounding budget it is documented to
+    # mirror, so the two bounds can't silently drift apart. Skip cleanly when
+    # the (desktop-only) backend package isn't present — this util ships in the
+    # core library independently of the FastAPI backend.
+    article_chat = pytest.importorskip("backend.article_chat")
+    assert rf._MAX_FULLTEXT_CHARS == article_chat.MAX_GROUNDING_CHARS
+
+
+def test_arxiv_reference_resolves_pdf_url_without_network():
+    url = rf._resolve_oa_pdf_url({"arxiv_id": "2310.06825"})
+    assert url and "2310.06825" in url and url.endswith(".pdf")
+
+
+def test_enrichment_oa_pdf_url_short_circuits_resolution():
+    ref = {"doi": "10.1/x", "enrichment": {"oa_pdf_url": "https://host/paper.pdf"}}
+    assert rf._resolve_oa_pdf_url(ref) == "https://host/paper.pdf"
+
+
+# --------------------------------------------------------------------------- #
+# OA miss → tldr fallback                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_no_oa_url_returns_tldr(monkeypatch):
+    monkeypatch.setattr(rf, "_resolve_oa_pdf_url", lambda r: None)
+    text, source = rf.get_reference_fulltext({"doi": "10.1145/3292500"})
+    assert text is None
+    assert source == "tldr"
+
+
+def test_too_short_extraction_is_a_miss(monkeypatch):
+    monkeypatch.setattr(rf, "_resolve_oa_pdf_url", lambda r: "https://host/p.pdf")
+    monkeypatch.setattr("refchecker.utils.url_utils.download_pdf_bytes", lambda url, **k: b"%PDF")
+    # A near-empty extraction (cover page / paywall stub) must NOT be trusted.
+    monkeypatch.setattr(rf, "_extract_pdf_text", lambda data: "tiny")
+    text, source = rf.get_reference_fulltext({"doi": "10.1145/3292500"})
+    assert text is None
+    assert source == "tldr"
+
+
+def test_no_identity_returns_tldr():
+    text, source = rf.get_reference_fulltext({})
+    assert text is None
+    assert source == "tldr"
+
+
+def test_download_error_soft_fails(monkeypatch):
+    monkeypatch.setattr(rf, "_resolve_oa_pdf_url", lambda r: "https://host/p.pdf")
+
+    def boom(url, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("refchecker.utils.url_utils.download_pdf_bytes", boom)
+    # Must not raise — soft-fails to the TL;DR fallback.
+    text, source = rf.get_reference_fulltext({"doi": "10.1145/3292500"})
+    assert text is None
+    assert source == "tldr"
+
+
+# --------------------------------------------------------------------------- #
+# Caching (positive + negative)                                               #
+# --------------------------------------------------------------------------- #
+
+def test_positive_cache_avoids_refetch(monkeypatch):
+    full = "G" * (rf._MIN_FULLTEXT_CHARS + 10)
+    calls = {"n": 0}
+
+    def fake_dl(url, **kwargs):
+        calls["n"] += 1
+        return b"%PDF"
+
+    monkeypatch.setattr(rf, "_resolve_oa_pdf_url", lambda r: "https://host/p.pdf")
+    monkeypatch.setattr("refchecker.utils.url_utils.download_pdf_bytes", fake_dl)
+    monkeypatch.setattr(rf, "_extract_pdf_text", lambda data: full)
+
+    ref = {"doi": "10.1145/3292500"}
+    t1, s1 = rf.get_reference_fulltext(ref)
+    t2, s2 = rf.get_reference_fulltext(ref)
+    assert (t1, s1) == (full, "pdf")
+    assert (t2, s2) == (full, "pdf")
+    assert calls["n"] == 1  # second call served from cache
+
+
+def test_negative_cache_avoids_refetch(monkeypatch):
+    resolves = {"n": 0}
+
+    def fake_resolve(reference):
+        resolves["n"] += 1
+        return None
+
+    monkeypatch.setattr(rf, "_resolve_oa_pdf_url", fake_resolve)
+    ref = {"doi": "10.1145/3292500"}
+    assert rf.get_reference_fulltext(ref) == (None, "tldr")
+    assert rf.get_reference_fulltext(ref) == (None, "tldr")
+    assert resolves["n"] == 1  # miss is cached; not re-resolved


### PR DESCRIPTION
A focused slice split out of umbrella PR #52, rebased clean on `main`.

**What:**
- `checkers/{openalex,crossref,semantic_scholar,arxiv_citation,local_semantic_scholar}.py` — request the extra fields the UI/CLI surface (citation counts, funders, abstracts, publication dates).
- `utils/enrichment.py` — cross-fills enrichment from all sources so a reference shows maximum real info (no fabrication; absent → omitted).
- `utils/reference_fulltext.py` — best-effort OA full-text fetch (arXiv/DOI→PDF), cached, used to ground chat/summarize.

Self-contained; **32 tests passing** (+1 skips when the FastAPI backend package isn't present, since this util also ships standalone in the core lib).

Part of splitting #52 into reviewable per-feature PRs.