### PR TITLE
AI-text detection: multi-detector compare, runtime manager & diagnostics

### DIFF
--- a/src/refchecker/ai_detection/__init__.py
+++ b/src/refchecker/ai_detection/__init__.py
@@ -66,6 +66,18 @@ def build_detector(backend: str, *, check_id=None, **opts) -> Optional[Detection
     return None
 
 
+def run_detectors(text_or_pages, keys):
+    """Run one or more registered detectors and compare them side-by-side.
+
+    Thin re-export of :func:`multi_run.run_detectors` so callers can use
+    ``from refchecker.ai_detection import run_detectors``. Returns the
+    per-detector results + the plain-code comparison summary (no synthetic
+    ensemble). An uninstalled detector abstains — it never reports a number.
+    """
+    from .multi_run import run_detectors as _rd
+    return _rd(text_or_pages, keys)
+
+
 def run_detection(
     text: str,
     *,
@@ -79,14 +91,36 @@ def run_detection(
     Always returns a result; on any failure returns an "unavailable" result
     with a machine-readable ``abstain_reason``.
     """
+    import time as _time
+    from . import diagnostics
+
     detector = build_detector(backend, check_id=check_id, **opts)
     if detector is None:
+        diagnostics.record({"backend": backend, "outcome": "unavailable",
+                            "reason": "unknown_backend"})
         return make_unavailable("unknown_backend", backend)
+    started = _time.monotonic()
     try:
-        return detector.detect(text, title=title)
+        result = detector.detect(text, title=title)
     except Exception as exc:  # noqa: BLE001
         logger.warning("AI detection (%s) raised: %s", backend, exc)
+        diagnostics.record({"backend": backend, "outcome": "error",
+                            "reason": "detection_error", "error": str(exc)[:200]})
         return make_unavailable("detection_error", backend)
+    # Record a text-free summary for the Settings debugger.
+    try:
+        diagnostics.record({
+            "backend": result.backend_used or backend,
+            "outcome": result.band,
+            "score": result.overall_score,
+            "reason": result.abstain_reason,
+            "word_count": result.word_count,
+            "spans": len(result.spans or []),
+            "duration_ms": int((_time.monotonic() - started) * 1000),
+        })
+    except Exception:  # noqa: BLE001
+        pass
+    return result
 
 
 __all__ = [
@@ -101,5 +135,6 @@ __all__ = [
     "VALID_BACKENDS",
     "build_detector",
     "run_detection",
+    "run_detectors",
     "model_manager",
 ]

--- a/src/refchecker/ai_detection/base.py
+++ b/src/refchecker/ai_detection/base.py
@@ -88,9 +88,25 @@ class SuspectSpan:
     quote: str
     reason: str = ""
     confidence: str = "medium"
+    # The richest signal the desklib detector exposes: this window's own model
+    # score (sigmoid prob in [0,1]). NOT a probability of guilt — surfaced only
+    # so the user can see WHICH passages drove the band and by how much.
+    model_score: Optional[float] = None
+    # How many physically-adjacent overlapping windows also cleared the high
+    # threshold (0, 1, or 2) — corroboration strength behind this passage.
+    neighbour_agreement_count: Optional[int] = None
+    # How the passage was validated ("multi_window_agreement").
+    confidence_method: Optional[str] = None
 
     def to_dict(self) -> Dict:
-        return {"quote": self.quote, "reason": self.reason, "confidence": self.confidence}
+        return {
+            "quote": self.quote,
+            "reason": self.reason,
+            "confidence": self.confidence,
+            "model_score": self.model_score,
+            "neighbour_agreement_count": self.neighbour_agreement_count,
+            "confidence_method": self.confidence_method,
+        }
 
 
 @dataclass
@@ -111,8 +127,24 @@ class AIDetectionResult:
     model_version: Optional[str] = None
     operating_point: Optional[str] = None
     abstain_reason: Optional[str] = None
+    # Human-readable detail for an abstention/failure (e.g. the underlying
+    # exception when the local model fails to load). Surfaced to the UI so the
+    # user can act on the REAL cause instead of a generic "failed to load".
+    abstain_detail: Optional[str] = None
     word_count: int = 0
     disclaimer: str = DISCLAIMER
+    # ── Optional richer visualisation payloads (populated by the local
+    # windowed backend; None/empty for backends that don't compute them). All
+    # are DESCRIPTIVE summaries of the model's windowed outputs — never a
+    # posterior probability of authorship. ──────────────────────────────────
+    # {"AI": frac, "Mixed": frac, "Human": frac} — fraction of scored windows
+    # whose score is high / medium / low. NOT P(AI-written).
+    probability_distribution: Optional[Dict[str, float]] = None
+    # Per heuristic ~page chunk: {page, start_word, end_word, score, span_count}.
+    per_page_scores: Optional[List[Dict]] = None
+    # Most/least AI-like sentences: {text, score, is_flagged}. Capped + advisory.
+    top_ai_sentences: Optional[List[Dict]] = None
+    top_human_sentences: Optional[List[Dict]] = None
 
     def to_dict(self) -> Dict:
         return {
@@ -125,21 +157,32 @@ class AIDetectionResult:
             "model_version": self.model_version,
             "operating_point": self.operating_point,
             "abstain_reason": self.abstain_reason,
+            "abstain_detail": self.abstain_detail,
             "word_count": self.word_count,
             "disclaimer": self.disclaimer,
+            "probability_distribution": self.probability_distribution,
+            "per_page_scores": self.per_page_scores,
+            "top_ai_sentences": self.top_ai_sentences,
+            "top_human_sentences": self.top_human_sentences,
         }
 
 
 # ── Convenience constructors ──────────────────────────────────────────────
 
 def make_unavailable(reason: str, backend: Optional[str] = None,
-                     word_count: int = 0) -> AIDetectionResult:
-    """No body text / missing deps / model-not-installed / timeout."""
+                     word_count: int = 0,
+                     detail: Optional[str] = None) -> AIDetectionResult:
+    """No body text / missing deps / model-not-installed / timeout.
+
+    ``detail`` carries the real underlying error (e.g. the load exception) so
+    the UI can show WHY it failed rather than a generic message.
+    """
     return AIDetectionResult(
         band=BAND_UNAVAILABLE,
         summary="AI-text detection could not run for this article.",
         backend_used=backend,
         abstain_reason=reason,
+        abstain_detail=detail,
         word_count=word_count,
     )
 
@@ -192,6 +235,12 @@ def should_abstain(text: str) -> Optional[str]:
     the most actionable reason.
     """
     wc = count_words(text)
+    if wc == 0:
+        # No manuscript body at all (e.g. references read from a .bbl/.bib file
+        # or a DOI lookup, so the full text was never extracted) — distinct from
+        # a genuinely short body, so the UI can explain it honestly rather than
+        # claim the text is "too short".
+        return "no_body_text"
     if wc < MIN_WORDS:
         return "too_short"
     if nonprose_fraction(text) > NONPROSE_FRACTION_ABSTAIN:
@@ -321,9 +370,69 @@ class DetectionBackend(ABC):
         """
 
 
+# ── Body-text cleanup (feed the detector authored prose, not boilerplate) ──
+
+# Start of the reference list / bibliography — everything after is citations.
+_REFS_HEADER_RE = re.compile(
+    r"(?im)^[^\S\n]*(?:references|bibliography|works\s+cited|literature\s+cited|"
+    r"reference\s+list)[^\S\n]*$"
+)
+
+# Journal front-matter / boilerplate the detector must NOT score: open-access /
+# Creative-Commons license blurbs, copyright lines, correspondence, affiliations,
+# DOIs, emails, received/accepted dates, keyword lines. These are templated and
+# score as "AI-like" but are not authored manuscript prose.
+_BOILERPLATE_LINE_RE = re.compile(
+    r"(?im)^(?:"
+    r".*(?:creative\s+commons|open\s+access|this\s+article\s+is\s+licensed|"
+    r"licensed\s+under|creativecommons\.org|all\s+rights\s+reserved|"
+    r"the\s+author\(s\)\s*\d{4}|©|correspondence|full\s+list\s+of\s+author|"
+    r"received\s*:.*accepted|https?://doi\.org|doi\.org/10\.|keywords).*"
+    r"|.*[\w.+-]+@[\w-]+\.[\w.-]+.*"
+    r")$"
+)
+
+
+def strip_nonbody(text: str) -> str:
+    """Remove journal boilerplate so the AI-detector scores authored prose, not
+    templated front-matter / references.
+
+    Drops, in order: the reference list, the title/author/affiliation/license
+    front-matter (by starting at the Abstract or Introduction), then residual
+    license / copyright / correspondence / email / DOI / keyword lines. Every
+    step is conservative — it only applies when >= MIN_WORDS of body survives,
+    so a short or unusually-formatted paper is never gutted.
+    """
+    if not text:
+        return text or ""
+    t = text
+
+    # 1) Cut the reference list tail.
+    m = None
+    for m in _REFS_HEADER_RE.finditer(t):
+        pass  # keep the LAST heading match (avoids "references" inside the intro)
+    if m and count_words(t[: m.start()]) >= MIN_WORDS:
+        t = t[: m.start()]
+
+    # 2) Start at the Abstract / Introduction to drop the leading front matter
+    #    (title, authors, affiliations, open-access license, correspondence).
+    for kw in (r"\bAbstract\b", r"\bIntroduction\b"):
+        am = re.search(kw, t, re.IGNORECASE)
+        if am and am.start() < len(t) * 0.4 and count_words(t[am.start():]) >= MIN_WORDS:
+            t = t[am.start():]
+            break
+
+    # 3) Scrub residual boilerplate lines wherever they sit in the body.
+    scrubbed = _BOILERPLATE_LINE_RE.sub("", t)
+    if count_words(scrubbed) >= MIN_WORDS:
+        t = scrubbed
+
+    return re.sub(r"[^\S\n]{2,}", " ", re.sub(r"\n{2,}", "\n", t)).strip()
+
+
 def prepared_text(text: str) -> Tuple[str, int]:
-    """Normalize whitespace and return ``(clean_text, word_count)``."""
-    clean = (text or "").strip()
+    """Clean boilerplate, normalize whitespace, return ``(clean_text, word_count)``."""
+    clean = strip_nonbody((text or "").strip())
     return clean, count_words(clean)
 
 

--- a/src/refchecker/ai_detection/diagnostics.py
+++ b/src/refchecker/ai_detection/diagnostics.py
@@ -1,0 +1,38 @@
+"""In-memory ring buffer of recent AI-detection runs, for the Settings debugger.
+
+Every call to :func:`run_detection` records one event here — backend used,
+outcome band/score, abstain/error reason, and duration — so a user (or we) can
+see *why* detection produced no band (e.g. ``unavailable: deps_not_installed``,
+``inconclusive: too_short``) without digging through server logs. Bounded and
+thread-safe; holds no manuscript text (only metadata).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Deque, Dict, List
+
+_CAP = 60
+_lock = threading.Lock()
+_events: Deque[Dict[str, object]] = deque(maxlen=_CAP)
+
+
+def record(event: Dict[str, object]) -> None:
+    """Append one detection event (a small, text-free metadata dict)."""
+    ev = dict(event)
+    ev.setdefault("ts", time.strftime("%Y-%m-%d %H:%M:%S"))
+    with _lock:
+        _events.append(ev)
+
+
+def events() -> List[Dict[str, object]]:
+    """Recent events, newest first."""
+    with _lock:
+        return list(reversed(_events))
+
+
+def clear() -> None:
+    with _lock:
+        _events.clear()

--- a/src/refchecker/ai_detection/local_backend.py
+++ b/src/refchecker/ai_detection/local_backend.py
@@ -1,10 +1,11 @@
 """Local calibrated detector backend (default engine).
 
 Runs the desklib ``ai-text-detector-v1.01`` model (DeBERTa-v3, MIT) entirely
-offline.  Preferred runtime is ``onnxruntime`` (PyInstaller-friendly, small);
-falls back to ``transformers`` + ``torch`` when only those are installed.  All
-ML imports are lazy and wrapped — a missing dependency or un-downloaded model
-yields an "unavailable" result, never a crash.
+offline.  The default model ships **safetensors**, so it runs via
+``transformers`` + ``torch``; the ``onnxruntime`` path is used only when a
+``model.onnx`` (with a classifier head) is present.  All ML imports are lazy
+and wrapped — a missing dependency or un-downloaded model yields an
+"unavailable" result, never a crash.
 
 Scoring is windowed (>= ~350-word windows, 50 % overlap).  The document score
 is the **mean** of window probabilities (a conservative aggregate — taking the
@@ -50,6 +51,13 @@ _MAX_TOKENS = 768  # per-window truncation for the encoder
 _engine = None
 _engine_lock = threading.Lock()
 
+# Per-detector engine cache for the multi-detector (R61) path. Keyed by
+# detector key; the default 'desklib' key shares the legacy ``_engine`` above
+# so an already-loaded default model is reused. Same double-checked-locking
+# discipline as _get_engine to avoid loading the same weights twice under a
+# cold-start batch.
+_engines: Dict[str, object] = {}
+
 
 def _ai_positive_index(id2label: Optional[Dict]) -> Optional[int]:
     """Pick the logit index whose label denotes AI/generated text.
@@ -94,8 +102,14 @@ class LocalDetectorBackend(DetectionBackend):
         try:
             engine = _get_engine()
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Local detector load failed: %s", exc)
-            return make_unavailable("model_load_failed", self.name, wc)
+            detail = _format_load_error(exc)
+            logger.warning("Local detector load failed: %s", detail)
+            try:
+                from . import diagnostics
+                diagnostics.record({"event": "model_load_failed", "detail": detail})
+            except Exception:  # noqa: BLE001
+                pass
+            return make_unavailable("model_load_failed", self.name, wc, detail=detail)
 
         # Only score windows that independently clear the SAME reliability
         # floors the document had to clear (>= MIN_WORDS prose, non-prose
@@ -114,8 +128,9 @@ class LocalDetectorBackend(DetectionBackend):
         try:
             probs = [engine.score(w) for w in windows]
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Local detector inference failed: %s", exc)
-            return make_unavailable("inference_failed", self.name, wc)
+            detail = _format_load_error(exc)
+            logger.warning("Local detector inference failed: %s", detail)
+            return make_unavailable("inference_failed", self.name, wc, detail=detail)
 
         doc_score = round(sum(probs) / len(probs), 3)
         raw_band = band_from_probability(doc_score)
@@ -132,11 +147,22 @@ class LocalDetectorBackend(DetectionBackend):
         # (capped) band is confusing dissonance. Mirrors the LLM backend.
         surfaced_score = None if band_rank(band) < band_rank(raw_band) else doc_score
 
-        # Local inference is free: record the processed word count for the
-        # usage meter (tokens proxy) with $0 cost.
-        record_detection_usage(self.check_id, self.model_version, input_tokens=wc, cost_usd=0.0)
+        # Local inference is free and is NOT an LLM call. Do not record the
+        # processed word count as input_tokens — doing so inflated the usage
+        # meter (e.g. "13k tokens · 2 LLM calls · $0.0000"), which read as paid
+        # API usage that should match a provider console but never would. The
+        # AI-detection result panel already surfaces that the local model ran;
+        # the cost/token meter is for PAID LLM work only.
 
         spans = _agreeing_spans(windows, probs, orig_idx) if band_rank(band) >= band_rank(BAND_MEDIUM) else []
+
+        # Descriptive visualisation payloads (donut distribution, per-page
+        # bands, representative sentences). Best-effort — never fail the result.
+        dist = per_page = top_ai = top_human = None
+        try:
+            dist, per_page, top_ai, top_human = _viz_payloads(engine, body, windows, probs, orig_idx)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("AI-detection viz payload skipped: %s", exc)
 
         return AIDetectionResult(
             band=band,
@@ -149,6 +175,10 @@ class LocalDetectorBackend(DetectionBackend):
             operating_point=OPERATING_POINT,
             word_count=wc,
             disclaimer=DISCLAIMER,
+            probability_distribution=dist,
+            per_page_scores=per_page,
+            top_ai_sentences=top_ai,
+            top_human_sentences=top_human,
         )
 
 
@@ -167,20 +197,127 @@ def _agreeing_spans(windows: List[str], probs: List[float],
     for i, p in enumerate(probs):
         if p < HIGH_THRESHOLD:
             continue
-        neighbour_high = (
-            (i > 0 and probs[i - 1] >= HIGH_THRESHOLD and orig_idx[i] - orig_idx[i - 1] == 1)
-            or (i < n - 1 and probs[i + 1] >= HIGH_THRESHOLD and orig_idx[i + 1] - orig_idx[i] == 1)
-        )
-        if not neighbour_high:
+        left_high = (i > 0 and probs[i - 1] >= HIGH_THRESHOLD and orig_idx[i] - orig_idx[i - 1] == 1)
+        right_high = (i < n - 1 and probs[i + 1] >= HIGH_THRESHOLD and orig_idx[i + 1] - orig_idx[i] == 1)
+        if not (left_high or right_high):
             continue
+        agree = int(bool(left_high)) + int(bool(right_high))
+        score = round(float(p), 3)
         spans.append(SuspectSpan(
             quote=truncate_quote(windows[i]),
-            reason="This passage scored above the high-likelihood threshold.",
+            reason=(
+                f"Model score {score:.2f} for this window, corroborated by "
+                f"{agree} adjacent passage{'s' if agree != 1 else ''} above the "
+                "high-likelihood threshold."
+            ),
             confidence="medium",
+            model_score=score,
+            neighbour_agreement_count=agree,
+            confidence_method="multi_window_agreement",
         ))
         if len(spans) >= 6:
             break
     return spans
+
+
+def _viz_payloads(engine, body: str, windows: List[str], probs: List[float],
+                  orig_idx: List[int]):
+    """Build the descriptive visualisation payloads from the windowed scores.
+
+    Returns (probability_distribution, per_page_scores, top_ai_sentences,
+    top_human_sentences). Everything here DESCRIBES the model's windowed
+    outputs — none of it is a probability that a human wrote the text.
+    """
+    import re as _re
+
+    n = len(probs)
+    if not n:
+        return None, None, None, None
+
+    # 1) Distribution over windows by band (donut + pills).
+    hi = sum(1 for p in probs if band_from_probability(p) == BAND_HIGH)
+    med = sum(1 for p in probs if band_from_probability(p) == BAND_MEDIUM)
+    low = n - hi - med
+    dist = {"AI": round(hi / n, 3), "Mixed": round(med / n, 3), "Human": round(low / n, 3)}
+
+    # 2) Per heuristic ~500-word page. Window position is approximated from its
+    #    original (pre-filter) index order — windows are emitted in reading
+    #    order with 50% overlap, so order tracks position well enough for a bar.
+    PAGE_WORDS = 500
+    total_words = max(1, len(body.split()))
+    num_pages = max(1, (total_words + PAGE_WORDS - 1) // PAGE_WORDS)
+    max_idx = max(orig_idx) if orig_idx else 1
+    page_probs = {}
+    page_wins = {}
+    for i, p in enumerate(probs):
+        frac = (orig_idx[i] / max_idx) if max_idx else 0.0
+        pg = min(num_pages - 1, int(frac * num_pages))
+        page_probs.setdefault(pg, []).append(p)
+        page_wins.setdefault(pg, []).append(i)
+
+    def _sentences(w):
+        out = []
+        for s in _re.split(r"(?<=[.!?])\s+", w):
+            s = s.strip()
+            if 40 <= len(s) <= 320:
+                out.append(s)
+            if len(out) >= 4:
+                break
+        return out
+
+    # 3) Per-PAGE sentence scoring. For each page, re-score a handful of real
+    #    sentences from that page's windows (highest-scoring windows first so
+    #    flagged sentences surface) — giving genuine per-sentence model scores,
+    #    not the window aggregate. A global budget caps total inferences so a
+    #    long document can't explode the cost; local inference is free but
+    #    serialized, so we keep it bounded.
+    sent_seen = set()
+    sent_budget = [160]
+
+    def _score_page_sentences(win_indices, cap=4):
+        out = []
+        for i in sorted(win_indices, key=lambda j: probs[j], reverse=True):
+            for s in _sentences(windows[i]):
+                if s in sent_seen or sent_budget[0] <= 0:
+                    continue
+                sent_seen.add(s)
+                sent_budget[0] -= 1
+                try:
+                    sc = float(engine.score(s))
+                except Exception:
+                    continue
+                out.append({"text": s, "score": round(sc, 3),
+                            "band": band_from_probability(sc),
+                            "is_flagged": band_from_probability(sc) == BAND_HIGH})
+                if len(out) >= cap:
+                    return out
+        return out
+
+    per_page = []
+    all_sentences = []
+    for pg in range(num_pages):
+        ps = page_probs.get(pg)
+        if not ps:
+            continue
+        score = round(sum(ps) / len(ps), 3)
+        psent = _score_page_sentences(page_wins.get(pg, []), cap=4)
+        all_sentences.extend(psent)
+        per_page.append({
+            "page": pg + 1,
+            "score": score,
+            "band": band_from_probability(score),
+            "window_count": len(ps),
+            # Per-sentence scores for this page (dotted breakdown) + this page's
+            # most-AI / most-human sentences.
+            "sentences": psent,
+            "top_ai": sorted(psent, key=lambda x: x["score"], reverse=True)[:2],
+            "top_human": sorted(psent, key=lambda x: x["score"])[:2],
+        })
+
+    # Document-level top AI/Human derived from the union of per-page sentences.
+    top_ai = sorted(all_sentences, key=lambda x: x["score"], reverse=True)[:6]
+    top_human = sorted(all_sentences, key=lambda x: x["score"])[:6]
+    return dist, per_page, top_ai, top_human
 
 
 def _summary(band: str, score, n_windows: int) -> str:
@@ -196,6 +333,49 @@ def _summary(band: str, score, n_windows: int) -> str:
 
 # ── Inference engine (lazy) ───────────────────────────────────────────────
 
+def _format_load_error(exc: Exception) -> str:
+    """Compact, user-actionable one-liner for a load/inference exception.
+
+    Includes the exception type and message, and — for the common
+    'model directory not found / missing config.json' case — the resolved
+    model path so a path mismatch is immediately obvious in the UI.
+    """
+    msg = f"{type(exc).__name__}: {exc}".strip()
+    try:
+        p = model_manager.model_path()
+        if isinstance(exc, (FileNotFoundError, OSError)) or "config.json" in msg or "does not appear" in msg:
+            msg = f"{msg} (model path: {p})"
+    except Exception:  # noqa: BLE001
+        pass
+    return msg[:500]
+
+
+def _build_engine_at(model_dir_path, head: Optional[str] = None):
+    """Construct an inference engine for the weights at ``model_dir_path``.
+
+    ``head`` is the registry's per-arch head hint ('custom_mean_pool' for
+    desklib's bespoke 1-logit head, 'sequence_classification' for the standard
+    RoBERTa/e5/Longformer ``AutoModelForSequenceClassification`` heads). The
+    engines auto-detect the right path from the checkpoint regardless (so the
+    hint is advisory), but it is threaded through for clarity and future arch
+    branches. Prefers an ONNX runtime when a ``model.onnx`` with a head is
+    present, else torch.
+    """
+    from pathlib import Path as _Path
+    p = _Path(str(model_dir_path))
+    path = str(p)
+    onnx_file = p / "model.onnx"
+    built = None
+    if onnx_file.is_file():
+        try:
+            built = _OnnxEngine(path, str(onnx_file))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ONNX engine unavailable, falling back to torch: %s", exc)
+    if built is None:
+        built = _TorchEngine(path)
+    return built
+
+
 def _get_engine():
     global _engine
     if _engine is not None:
@@ -206,39 +386,124 @@ def _get_engine():
     with _engine_lock:
         if _engine is not None:
             return _engine
-        path = str(model_manager.model_path())
-        onnx_file = model_manager.model_path() / "model.onnx"
-        built = None
-        if onnx_file.is_file():
-            try:
-                built = _OnnxEngine(path, str(onnx_file))
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("ONNX engine unavailable, falling back to torch: %s", exc)
-        if built is None:
-            built = _TorchEngine(path)
-        _engine = built
+        # Defensive: make the pip-installed runtime importable even if detect()
+        # was reached without a prior deps_available() call (e.g. a fresh worker
+        # thread). deps_available() also does this, but calling it here too is
+        # idempotent and closes the "runtime not on sys.path at load time" gap.
+        try:
+            from . import runtime_manager
+            runtime_manager.ensure_on_path()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("ensure_on_path before engine load failed: %s", exc)
+        _engine = _build_engine_at(model_manager.model_path(), head="custom_mean_pool")
         return _engine
+
+
+def load(detector_key: str):
+    """Load (and cache) the inference engine for a given detector ``key``.
+
+    Per-arch head selection is driven by the registry entry's ``head`` field
+    and the engine's own checkpoint introspection. The default ``desklib`` key
+    reuses the legacy process-wide engine (``_get_engine``) so an already-loaded
+    default model is not re-loaded. Raises if the detector is unknown,
+    not installable (Tier-2 heavy), or not installed — callers MUST treat a
+    raise as "abstain", never fabricate a score.
+    """
+    key = (detector_key or "").strip().lower()
+    entry = model_manager.get_detector(key)
+    if not entry:
+        raise ValueError(f"unknown detector: {detector_key!r}")
+    if not entry.get("installable"):
+        raise ValueError(f"detector {key!r} is not runnable in this build")
+    if key == model_manager.DEFAULT_DETECTOR:
+        return _get_engine()
+    cached = _engines.get(key)
+    if cached is not None:
+        return cached
+    with _engine_lock:
+        cached = _engines.get(key)
+        if cached is not None:
+            return cached
+        if not model_manager.is_detector_installed(key):
+            raise FileNotFoundError(f"detector {key!r} is not installed")
+        try:
+            from . import runtime_manager
+            runtime_manager.ensure_on_path()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("ensure_on_path before engine load failed: %s", exc)
+        built = _build_engine_at(model_manager.detector_dir(key), head=str(entry.get("head")))
+        _engines[key] = built
+        return built
+
+
+def _load_checkpoint_state_dict(model_dir: str):
+    """Load a checkpoint's tensors directly (safetensors preferred, then .bin).
+
+    Returns a state-dict mapping or None if no weight file is present. Avoids
+    the version-sensitive ``from_pretrained`` path so the desklib model loads
+    consistently across transformers releases.
+    """
+    import os
+    st = os.path.join(model_dir, "model.safetensors")
+    if os.path.isfile(st):
+        from safetensors.torch import load_file
+        return load_file(st)
+    for fname in ("pytorch_model.bin", "model.bin"):
+        binp = os.path.join(model_dir, fname)
+        if os.path.isfile(binp):
+            import torch
+            return torch.load(binp, map_location="cpu")
+    return None
 
 
 class _TorchEngine:
     """transformers + torch runtime for the desklib custom model."""
 
     def __init__(self, model_dir: str):
+        import warnings
         import torch
-        from transformers import AutoTokenizer, AutoConfig, AutoModel, PreTrainedModel
+        from transformers import AutoTokenizer, AutoConfig, AutoModel
         import torch.nn as nn
 
         self.torch = torch
-        self.tokenizer = AutoTokenizer.from_pretrained(model_dir)
+        # The engine is a process-wide singleton (see _get_engine), so during a
+        # BATCH run several worker threads call score() on the SAME tokenizer +
+        # model at once. The HF fast tokenizer is a Rust object that raises
+        # "RuntimeError: Already borrowed" when borrowed concurrently, and torch
+        # CPU inference isn't guaranteed thread-safe either — serialise both.
+        self._infer_lock = threading.Lock()
+        # Suppress warnings around EVERY transformers call below. A warning
+        # emitted while a frame of THIS module is on the stack makes the warnings
+        # formatter read this file's source; in a PyInstaller bundle that read
+        # used to raise FileNotFoundError (see the longer note below). The
+        # tokenizer/config loads warn too, so they must be wrapped as well — not
+        # just model construction. (Source is also now shipped in the bundle as a
+        # second layer of defence; see the spec's `.py` datas block.)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # local_files_only: the model is verified installed on disk before
+            # we ever build an engine (LocalDetectorBackend.detect guards on
+            # is_model_installed). Forcing offline here means from_pretrained can
+            # NEVER reach out to the Hugging Face hub to "check for a newer
+            # revision" — a network call that, on a flaky connection, could hang
+            # this load far past the AI-detection budget. Belt to the existing
+            # asyncio.wait_for(480) suspenders: load is purely local I/O now.
+            self.tokenizer = AutoTokenizer.from_pretrained(model_dir, local_files_only=True)
 
-        class _DesklibModel(PreTrainedModel):
-            config_class = AutoConfig
-
+        # Plain nn.Module — deliberately NOT a transformers PreTrainedModel.
+        # Subclassing PreTrainedModel dragged in its version-fragile construction
+        # surface (init_weights/tie_weights → `all_tied_weights_keys`,
+        # `_tied_weights_keys`, post_init, ignore_mismatched_sizes …), which
+        # breaks differently on every transformers release the user happens to
+        # have pip-installed into the runtime. We only need an encoder + a linear
+        # head + forward, and we load the weights ourselves with
+        # load_state_dict(strict=False) — so a bare nn.Module is both sufficient
+        # and immune to that API drift (verified: identical scores).
+        class _DesklibModel(nn.Module):
             def __init__(self, config):
-                super().__init__(config)
+                super().__init__()
                 self.model = AutoModel.from_config(config)
                 self.classifier = nn.Linear(config.hidden_size, 1)
-                self.init_weights()
 
             def forward(self, input_ids, attention_mask=None, **_):
                 outputs = self.model(input_ids, attention_mask=attention_mask)
@@ -250,14 +515,58 @@ class _TorchEngine:
                 return self.classifier(pooled)
 
         self._ai_index: Optional[int] = None
-        _info = None
-        try:
-            self.model, _info = _DesklibModel.from_pretrained(model_dir, output_loading_info=True)
-        except Exception:  # noqa: BLE001
-            # Fall back to a standard sequence-classification head if the
-            # installed model isn't the desklib custom architecture.
+        self._std = None
+
+        # Load the desklib checkpoint by building the architecture and loading
+        # the weights DIRECTLY from the checkpoint file — version-robust.
+        #
+        # The HF `from_pretrained` dance fails on some transformers versions and
+        # silently falls back to a sequence-classification head whose
+        # [num_labels, hidden] classifier mismatches the desklib [1, hidden]
+        # head — producing the "You set ignore_mismatched_sizes to False"
+        # RuntimeError users hit. Loading the state dict ourselves and applying
+        # it with strict=False sidesteps that machinery entirely (verified to
+        # produce scores identical to a successful from_pretrained load).
+        # Build + load INSIDE catch_warnings. A warning emitted from a frame in
+        # this module (e.g. transformers' weight-init notice during
+        # `_DesklibModel.__init__`) makes the warnings machinery read this file's
+        # SOURCE to format the message. In a PyInstaller bundle the `.py` source
+        # is not extracted, so that read raises
+        # `FileNotFoundError: …/_MEIxxxx/refchecker/ai_detection/local_backend.py`
+        # which surfaced as "model failed to load". Suppressing warnings here
+        # removes the source-format step entirely (we do our own strict checks).
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            config = AutoConfig.from_pretrained(model_dir, local_files_only=True)
+        state_dict = _load_checkpoint_state_dict(model_dir)
+
+        if state_dict is not None and any(k.startswith("classifier") for k in state_dict):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                model = _DesklibModel(config)
+                result = model.load_state_dict(state_dict, strict=False)
+            missing = list(getattr(result, "missing_keys", []) or [])
+            missing_clf = [k for k in missing if k.startswith("classifier")]
+            missing_enc = [k for k in missing if k.startswith("model.")]
+            # Refuse to score with a partially-random model (a random classifier
+            # head could band human text high).
+            if missing_clf or missing_enc:
+                raise ValueError(
+                    "desklib weights did not load cleanly (missing classifier="
+                    f"{missing_clf}, missing {len(missing_enc)} encoder tensors); "
+                    "refusing to score with a partially-initialised model."
+                )
+            model.eval()
+            self.model = model
+        else:
+            # Not the desklib checkpoint — try a standard sequence-classification
+            # head (e.g. a user-supplied alternative detector model).
             from transformers import AutoModelForSequenceClassification
-            self._std = AutoModelForSequenceClassification.from_pretrained(model_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self._std = AutoModelForSequenceClassification.from_pretrained(
+                    model_dir, local_files_only=True
+                )
             self.model = None
             self._std.eval()
             num_labels = int(getattr(self._std.config, "num_labels", 1) or 1)
@@ -271,26 +580,20 @@ class _TorchEngine:
                         "id2label; refusing to guess. Use a single-logit detector "
                         "or a model with clearly labelled classes."
                     )
-        else:
-            # If the checkpoint didn't actually contain the classifier head,
-            # from_pretrained leaves it at random init and does NOT raise —
-            # scoring would then return sigmoid over garbage. Refuse rather
-            # than fabricate scores (a random head could band human text high).
-            missing = set((_info or {}).get("missing_keys") or [])
-            if any(k.startswith("classifier") for k in missing):
-                raise ValueError(
-                    "desklib classifier head missing from the checkpoint "
-                    "(would score with a random head); refusing to run."
-                )
-            self.model.eval()
-            self._std = None
 
     def score(self, text: str) -> float:
+        import warnings
         torch = self.torch
-        enc = self.tokenizer(
-            text, truncation=True, max_length=_MAX_TOKENS, return_tensors="pt"
-        )
-        with torch.no_grad():
+        # Same frozen-bundle guard as __init__: a warning emitted from the
+        # tokenizer or from `_DesklibModel.forward` (this module) would try to
+        # read the missing source file. Suppress so inference never raises
+        # FileNotFoundError. The lock serialises concurrent batch threads
+        # (fixes "RuntimeError: Already borrowed" on the shared tokenizer).
+        with self._infer_lock, warnings.catch_warnings(), torch.no_grad():
+            warnings.simplefilter("ignore")
+            enc = self.tokenizer(
+                text, truncation=True, max_length=_MAX_TOKENS, return_tensors="pt"
+            )
             if self.model is not None:
                 logit = self.model(enc["input_ids"], attention_mask=enc["attention_mask"])
                 return float(torch.sigmoid(logit).squeeze().item())
@@ -305,19 +608,32 @@ class _OnnxEngine:
     """onnxruntime runtime (used only if a model.onnx with a head exists)."""
 
     def __init__(self, model_dir: str, onnx_path: str):
+        import warnings
         import onnxruntime as ort
         from transformers import AutoTokenizer, AutoConfig
         import numpy as np
 
         self.np = np
-        self.tokenizer = AutoTokenizer.from_pretrained(model_dir)
+        # Serialise concurrent batch threads on the shared tokenizer/session
+        # (see _TorchEngine note — fixes "Already borrowed").
+        self._infer_lock = threading.Lock()
+        # Same frozen-bundle guard as _TorchEngine: suppress warnings around the
+        # transformers calls so the formatter never reads this module's source.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # local_files_only: the model dir is verified-installed before any
+            # engine is built; never let from_pretrained hit the network (see
+            # the _TorchEngine note — avoids a hung hub call past the budget).
+            self.tokenizer = AutoTokenizer.from_pretrained(model_dir, local_files_only=True)
         self.session = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
         self.input_names = {i.name for i in self.session.get_inputs()}
         # Resolve the AI-positive class index from the config for multi-class
         # heads (single-logit heads use sigmoid and ignore this).
         self._ai_index: Optional[int] = None
         try:
-            cfg = AutoConfig.from_pretrained(model_dir)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                cfg = AutoConfig.from_pretrained(model_dir, local_files_only=True)
             if int(getattr(cfg, "num_labels", 1) or 1) > 1:
                 self._ai_index = _ai_positive_index(getattr(cfg, "id2label", None))
         except Exception:  # noqa: BLE001
@@ -325,11 +641,12 @@ class _OnnxEngine:
 
     def score(self, text: str) -> float:
         np = self.np
-        enc = self.tokenizer(
-            text, truncation=True, max_length=_MAX_TOKENS, return_tensors="np"
-        )
-        feeds = {k: v for k, v in enc.items() if k in self.input_names}
-        out = self.session.run(None, feeds)[0]
+        with self._infer_lock:
+            enc = self.tokenizer(
+                text, truncation=True, max_length=_MAX_TOKENS, return_tensors="np"
+            )
+            feeds = {k: v for k, v in enc.items() if k in self.input_names}
+            out = self.session.run(None, feeds)[0]
         arr = np.asarray(out).reshape(-1)
         if arr.size == 1:
             return float(1.0 / (1.0 + np.exp(-arr[0])))

--- a/src/refchecker/ai_detection/model_manager.py
+++ b/src/refchecker/ai_detection/model_manager.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import sys
 import threading
 from pathlib import Path
 from typing import Dict, Optional
@@ -23,8 +24,177 @@ from typing import Dict, Optional
 logger = logging.getLogger(__name__)
 
 #: HuggingFace repo for the default local detector (DeBERTa-v3, MIT licence).
+#: Kept as a module-level constant for full backward-compatibility: the
+#: original single-detector code path (the legacy ``model_*`` /
+#: ``start_download`` / ``delete_model`` functions below, the ``local_backend``
+#: engine, and the existing ``/api/ai-detection/model/*`` endpoints) all still
+#: operate on this one repo. The new multi-detector API layers on top via
+#: :data:`DETECTOR_REGISTRY` + the ``detector_*`` functions, and the
+#: ``desklib`` registry entry resolves to the SAME on-disk path, so existing
+#: installs are picked up unchanged.
 MODEL_REPO = "desklib/ai-text-detector-v1.01"
 _MODEL_DIRNAME = "desklib-ai-text-detector-v1.01"
+
+
+# ── Multi-detector registry (R61 / §14) ───────────────────────────────────
+#
+# Each entry describes ONE installable open-source AI-text detector. Tier-1
+# detectors are classifier heads we can actually load + run locally; Tier-2
+# ("heavy") metric/zero-shot detectors are listed for honesty but marked
+# ``installable: False`` until a real runner exists — they are NEVER selectable
+# to run and NEVER report a fabricated number. ``arch``/``head`` drive the
+# per-arch loader in ``local_backend``:
+#   * ``custom_mean_pool`` — desklib's bespoke mean-pooled DeBERTa + 1-logit head
+#   * ``sequence_classification`` — standard ``AutoModelForSequenceClassification``
+#     (RoBERTa / e5 / Longformer), sigmoid for 1 logit else softmax[ai_index].
+#
+# ``threshold`` is this detector's own score→"high" cut point (per-detector, not
+# a shared global) so each model is banded on its own calibration. ``size_mb``
+# and ``license`` are REAL, research-verified values shown to the user before
+# install (no invented numbers). ``raid_note`` is the one-line provenance.
+
+DEFAULT_DETECTOR = "desklib"
+
+DETECTOR_REGISTRY: Dict[str, Dict[str, object]] = {
+    "desklib": {
+        "key": "desklib",
+        "repo": "desklib/ai-text-detector-v1.01",
+        "arch": "deberta-v3-large",
+        "head": "custom_mean_pool",
+        "size_mb": 870,
+        "tier": 1,
+        "threshold": 0.85,
+        "license": "MIT",
+        "raid_note": "RAID leaderboard leader among open models (default).",
+        "installable": True,
+        "heavy": False,
+        "label": "Desklib (DeBERTa-v3-large)",
+        "dirname": _MODEL_DIRNAME,
+    },
+    "superannotate": {
+        "key": "superannotate",
+        "repo": "SuperAnnotate/ai-detector",
+        "arch": "roberta-large",
+        "head": "sequence_classification",
+        "size_mb": 1420,
+        "tier": 1,
+        "threshold": 0.85,
+        "license": "SuperAnnotate (research/eval)",
+        "raid_note": "#1 open-source on RAID (late 2024); a low-FPR variant "
+                     "(SuperAnnotate/ai-detector-low-fpr) also exists.",
+        "installable": True,
+        "heavy": False,
+        "label": "SuperAnnotate (RoBERTa-Large)",
+        "dirname": "superannotate-ai-detector",
+    },
+    "e5-small-lora": {
+        "key": "e5-small-lora",
+        "repo": "MayZhou/e5-small-lora-ai-generated-detector",
+        "arch": "e5-small",
+        "head": "sequence_classification",
+        "size_mb": 130,
+        "tier": 1,
+        "threshold": 0.85,
+        "license": "MIT",
+        "raid_note": "RAID-optimized, tiny/fast/CPU-friendly (~89% acc; "
+                     "ONNX port exists).",
+        "installable": True,
+        "heavy": False,
+        "label": "e5-small + LoRA",
+        "dirname": "e5-small-lora-ai-generated-detector",
+    },
+    "mage": {
+        "key": "mage",
+        "repo": "yaful/MAGE",
+        "arch": "longformer",
+        "head": "sequence_classification",
+        "size_mb": 570,
+        "tier": 1,
+        "threshold": 0.85,
+        "license": "Apache-2.0",
+        "raid_note": "\"Detection in the wild\" (ACL 2024); strong "
+                     "out-of-domain.",
+        "installable": True,
+        "heavy": False,
+        "label": "MAGE (Longformer)",
+        "dirname": "mage-longformer",
+    },
+    # ── Tier-2 heavy metric / zero-shot detectors. Listed for honesty; NOT
+    # runnable in this build → installable=False so the API refuses to install
+    # or select them, and they never report a number. The size/RAM warnings are
+    # real so the FE can show why they are opt-in. ────────────────────────────
+    "binoculars": {
+        "key": "binoculars",
+        "repo": "(paired causal LMs)",
+        "arch": "metric-zeroshot",
+        "head": "metric",
+        "size_mb": 14000,
+        "tier": 2,
+        "threshold": None,
+        "license": "see component models",
+        "raid_note": "Best-in-class at low FPR; needs TWO LLMs loaded "
+                     "simultaneously — heavy RAM/VRAM. Not runnable in this "
+                     "build.",
+        "installable": False,
+        "heavy": True,
+        "label": "Binoculars (zero-shot, 2 LLMs)",
+        "dirname": "binoculars",
+    },
+    "fast-detectgpt": {
+        "key": "fast-detectgpt",
+        "repo": "(GPT-Neo-2.7B scorer)",
+        "arch": "metric-zeroshot",
+        "head": "metric",
+        "size_mb": 11000,
+        "tier": 2,
+        "threshold": None,
+        "license": "see component models",
+        "raid_note": "340x faster than DetectGPT; ~11 GB scorer download. Not "
+                     "runnable in this build.",
+        "installable": False,
+        "heavy": True,
+        "label": "Fast-DetectGPT (zero-shot)",
+        "dirname": "fast-detectgpt",
+    },
+    "radar": {
+        "key": "radar",
+        "repo": "TrustSafeAI/RADAR-Vicuna-7B",
+        "arch": "vicuna-7b",
+        "head": "metric",
+        "size_mb": 13000,
+        "tier": 2,
+        "threshold": None,
+        "license": "see model card",
+        "raid_note": "Adversarially-trained, robust to paraphrase; 7B-scale "
+                     "(~13 GB) download. Not runnable in this build.",
+        "installable": False,
+        "heavy": True,
+        "label": "RADAR (Vicuna-7B)",
+        "dirname": "radar-vicuna-7b",
+    },
+}
+
+#: Detector keys that can actually be installed + run locally (Tier-1).
+def runnable_detector_keys() -> list:
+    return [k for k, v in DETECTOR_REGISTRY.items() if v.get("installable")]
+
+
+def get_detector(key: str) -> Optional[Dict[str, object]]:
+    """Return the registry entry for ``key`` (None if unknown)."""
+    return DETECTOR_REGISTRY.get((key or "").strip().lower())
+
+
+def detector_dir(key: str) -> Path:
+    """On-disk directory for detector ``key``'s weights.
+
+    ``desklib`` resolves to the SAME path the legacy single-detector code uses
+    (``model_path()``), so an already-installed desklib model is picked up by
+    the new API without a re-download.
+    """
+    entry = get_detector(key)
+    if not entry:
+        raise KeyError(f"unknown detector: {key!r}")
+    return model_storage_dir() / str(entry["dirname"])
 
 # Background download state (single global model, single download at a time).
 _lock = threading.Lock()
@@ -34,6 +204,31 @@ _status: Dict[str, object] = {
     "repo": MODEL_REPO,
 }
 _thread: Optional[threading.Thread] = None
+
+# Rolling download log surfaced to the Settings debugger (so a failed model
+# download shows the real reason instead of failing silently).
+_LOG_CAP = 200
+_log: list = []
+
+
+def _log_line(msg: str) -> None:
+    import time
+    stamp = time.strftime("%H:%M:%S")
+    with _lock:
+        for line in (str(msg).splitlines() or [""]):
+            _log.append(f"{stamp}  {line}")
+        if len(_log) > _LOG_CAP:
+            del _log[: len(_log) - _LOG_CAP]
+
+
+def _log_reset() -> None:
+    with _lock:
+        _log.clear()
+
+
+def get_log(limit: int = 120) -> list:
+    with _lock:
+        return _log[-limit:]
 
 
 def model_storage_dir() -> Path:
@@ -53,17 +248,120 @@ def model_path() -> Path:
 
 
 _WEIGHT_FILES = ("model.onnx", "model.safetensors", "pytorch_model.bin")
+#: Written ONLY after a download is verified complete (weight file size matches
+#: the repo's expected size). Required for "installed" so a partial/truncated
+#: download — e.g. a SIGKILLed resume that left a short model.safetensors — is
+#: never accepted (it would fail or score with garbage at inference).
+_OK_MARKER = ".refcheck_model_ok"
 
 
 def is_model_installed() -> bool:
-    # Require an actual weight artifact, not just config.json — snapshot_download
-    # writes the tiny config first, so checking only config.json would report
-    # "installed" mid-download (premature poll-loop exit + a spurious
-    # model_load_failed if a check starts before the weights land).
+    # Require config.json, a real weight artifact, AND the completion marker —
+    # checking only that the weight file *exists* would accept a truncated
+    # download (snapshot_download writes config first; a partial weight file can
+    # linger). The marker is written only after the size is verified complete.
     p = model_path()
     if not (p.is_dir() and (p / "config.json").is_file()):
         return False
-    return any((p / f).is_file() for f in _WEIGHT_FILES)
+    if not any((p / f).is_file() for f in _WEIGHT_FILES):
+        return False
+    return (p / _OK_MARKER).is_file()
+
+
+def _model_complete(expected_weight_bytes: int) -> bool:
+    """True when config + a weight file are present and the (largest) weight
+    file is at least 99% of its expected size — the authoritative completeness
+    check the worker runs before writing the marker."""
+    p = model_path()
+    if not (p.is_dir() and (p / "config.json").is_file()):
+        return False
+    weights = [p / f for f in _WEIGHT_FILES if (p / f).is_file()]
+    if not weights:
+        return False
+    try:
+        biggest = max(w.stat().st_size for w in weights)
+    except OSError:
+        return False
+    if expected_weight_bytes > 0:
+        return biggest >= int(expected_weight_bytes * 0.99)
+    return biggest > 50 * 1024 * 1024  # no expected size known → 50 MB sanity floor
+
+
+def _write_ok_marker() -> None:
+    try:
+        (model_path() / _OK_MARKER).write_text("ok\n")
+    except OSError:
+        pass
+
+
+_MODEL_INFO_FILE = ".refcheck_model_info.json"
+
+
+def _resolve_latest_revision():
+    """Best-effort: the current HEAD commit sha of the model repo on Hugging
+    Face. Returns None on any failure (offline, rate-limited, hf_hub missing)."""
+    try:
+        from huggingface_hub import HfApi
+        info = HfApi().model_info(MODEL_REPO)
+        return getattr(info, "sha", None) or getattr(info, "lastModified", None)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _write_model_info() -> None:
+    """Record the resolved HF revision + timestamp at download time so a later,
+    explicitly-invoked check can tell whether the repo has since updated. Never
+    fatal — a missing info file just means the next check reports 'unknown'."""
+    try:
+        import json
+        from datetime import datetime, timezone
+        info = {
+            "repo": MODEL_REPO,
+            "resolved_revision": _resolve_latest_revision(),
+            "download_timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        (model_path() / _MODEL_INFO_FILE).write_text(json.dumps(info))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def query_update_available() -> Dict[str, object]:
+    """Is a newer revision of the model available on Hugging Face?
+
+    EXPLICITLY invoked (e.g. when the Settings panel opens) — NEVER call this
+    from model_status(), which the UI polls every 1-2s during downloads; the HF
+    round-trip must not sit on that hot path. Network failures degrade to
+    'unable_to_check' so the caller never breaks.
+    """
+    if not is_model_installed():
+        return {"update_available": False, "status": "not_installed"}
+    try:
+        import json
+        info_path = model_path() / _MODEL_INFO_FILE
+        stored = None
+        if info_path.is_file():
+            try:
+                stored = (json.loads(info_path.read_text()) or {}).get("resolved_revision")
+            except Exception:  # noqa: BLE001
+                stored = None
+        latest = _resolve_latest_revision()
+        if latest is None:
+            return {"update_available": False, "status": "unable_to_check", "repo": MODEL_REPO}
+        if stored is None:
+            # Installed before update-tracking existed — record current as
+            # baseline so we don't nag, and report no update this time.
+            _write_model_info()
+            return {"update_available": False, "status": "baseline_recorded",
+                    "latest_revision": str(latest), "repo": MODEL_REPO}
+        return {
+            "update_available": str(stored) != str(latest),
+            "status": "checked",
+            "current_revision": str(stored),
+            "latest_revision": str(latest),
+            "repo": MODEL_REPO,
+        }
+    except Exception:  # noqa: BLE001
+        return {"update_available": False, "status": "unable_to_check", "repo": MODEL_REPO}
 
 
 def _dir_size_bytes(path: Path) -> int:
@@ -83,6 +381,7 @@ def model_status() -> Dict[str, object]:
     with _lock:
         state = _status.get("state")
         message = _status.get("message", "")
+        log = list(_log[-120:])
     # If a previous process installed it, reflect that even when state==idle.
     if installed and state not in ("downloading",):
         state = "installed"
@@ -95,54 +394,247 @@ def model_status() -> Dict[str, object]:
         "path": str(model_path()),
         "size_bytes": size,
         "deps_available": deps_available(),
+        "log": log,
     }
 
 
 def deps_available() -> bool:
-    """Whether an inference runtime (onnxruntime OR torch+transformers) exists."""
+    """Whether an inference runtime (onnxruntime OR torch+transformers) exists.
+
+    Delegates to :mod:`runtime_manager`, which first makes an on-demand
+    ``--target`` runtime install (if any) importable by prepending it to
+    ``sys.path`` — so a runtime the user installed from the app is detected
+    without restarting the server.
+    """
+    from . import runtime_manager
+    return runtime_manager.deps_available()
+
+
+def _safe_mb(path: Path) -> float:
     try:
-        import onnxruntime  # noqa: F401
-        import transformers  # noqa: F401
-        return True
+        return _dir_size_bytes(path) / (1024 * 1024)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def _set_progress(mb: float, total_mb: float) -> None:
+    if total_mb:
+        pct = min(99, int(mb * 100 / total_mb))
+        msg = f"Downloading… {mb:.0f} / {total_mb:.0f} MB ({pct}%)"
+    else:
+        msg = f"Downloading… {mb:.0f} MB"
+    with _lock:
+        if _status.get("state") == "downloading":
+            _status["message"] = msg
+
+
+def _fetch_sizes() -> tuple:
+    """(total_mb, max_weight_bytes) from repo metadata — for the % display and
+    the completeness check. (total_mb, 0) on failure."""
+    try:
+        from huggingface_hub import HfApi
+        info = HfApi().model_info(MODEL_REPO, files_metadata=True)
+        sizes = [(getattr(s, "size", 0) or 0) for s in (info.siblings or [])]
+        total_mb = sum(sizes) / (1024 * 1024)
+        max_weight = max(sizes) if sizes else 0  # the safetensors/bin is the big one
+        _log_line(f"total size ~{total_mb:.0f} MB (weight ~{max_weight / (1024*1024):.0f} MB)")
+        return total_mb, max_weight
+    except Exception as exc:  # noqa: BLE001
+        _log_line(f"(could not fetch total size: {exc})")
+        return 0.0, 0
+
+
+def run_hf_download_cli(repo: str, dest: str) -> int:
+    """Run snapshot_download in THIS clean process — the bundle's --hf-download
+    mode. HF_HUB_DISABLE_XET is set BEFORE huggingface_hub is imported, which is
+    the only reliable way to disable the Xet backend (it stalls in the bundle);
+    `import hf_xet` is also blocked as a belt. A fresh standard LFS download."""
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
+    os.environ.setdefault("HF_HUB_ETAG_TIMEOUT", "30")
+    sys.modules.setdefault("hf_xet", None)  # makes `import hf_xet` raise → xet off
+    try:
+        from . import runtime_manager
+        runtime_manager.ensure_on_path()
     except Exception:  # noqa: BLE001
         pass
     try:
-        import torch  # noqa: F401
-        import transformers  # noqa: F401
-        return True
-    except Exception:  # noqa: BLE001
+        from huggingface_hub import snapshot_download
+    except Exception as exc:  # noqa: BLE001
+        import traceback
+        traceback.print_exc()
+        print(f"hf import failed: {exc}", flush=True)
+        return 1
+    try:
+        snapshot_download(repo_id=repo, local_dir=dest)
+        print("HF_DOWNLOAD_OK", flush=True)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        import traceback
+        traceback.print_exc()
+        print(f"download error: {exc}", flush=True)
+        return 1
+
+
+def _download_supervised(dest: Path, total_mb: float, expected_weight: int) -> bool:
+    """Frozen desktop: download in a CLEAN subprocess (Xet truly off). The key
+    lesson from the field: do NOT SIGKILL hf_hub mid-download — that corrupts its
+    resume state and restarts from ~0. Instead let each subprocess run to its
+    natural exit (hf_hub retries+resumes internally via the read timeout), then
+    re-run to RESUME cleanly from the consistent .incomplete. SIGKILL only as a
+    true-hang last resort (no progress AND no exit for 6 minutes)."""
+    import subprocess
+    import time
+    for attempt in range(1, 11):
+        start_mb = _safe_mb(dest)
+        _log_line(f"download attempt {attempt} (xet off, resuming from {start_mb:.0f} MB)")
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+        proc = subprocess.Popen(
+            [sys.executable, "--hf-download", MODEL_REPO, str(dest)],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
+        )
+        out: list = []
+        threading.Thread(
+            target=lambda: [out.append(ln.rstrip("\n")) for ln in proc.stdout], daemon=True,
+        ).start()
+        last_mb, last_advance, tick = start_mb, time.monotonic(), 0
+        while proc.poll() is None:
+            time.sleep(3)
+            mb = _safe_mb(dest)
+            _set_progress(mb, total_mb)
+            tick += 1
+            if tick % 6 == 0:  # ~18s
+                _log_line(f"progress: {mb:.0f} / {total_mb:.0f} MB" if total_mb else f"progress: {mb:.0f} MB")
+            if mb >= last_mb + 1:
+                last_mb, last_advance = mb, time.monotonic()
+            elif time.monotonic() - last_advance > 360:  # 6 min, genuine hang
+                _log_line(f"no progress for 6 min at {mb:.0f} MB — restarting the process (resume)")
+                proc.kill()
+                break
+        try:
+            proc.wait(timeout=15)
+        except Exception:  # noqa: BLE001
+            proc.kill()
+        if _model_complete(expected_weight):
+            return True
+        _log_line(f"attempt {attempt} ended (exit={proc.returncode}); not complete yet — "
+                  f"{' | '.join(out[-3:])}")
+        time.sleep(2)  # brief backoff before resuming
+    return _model_complete(expected_weight)
+
+
+def _download_in_process(dest: Path, total_mb: float, expected_weight: int) -> bool:
+    """Source install: in-process snapshot_download with Xet disabled + a live
+    size reporter (no frozen-bundle Xet-stall concerns here)."""
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
+    sys.modules.setdefault("hf_xet", None)
+    try:
+        from huggingface_hub import snapshot_download
+    except Exception as exc:  # noqa: BLE001
+        import traceback
+        _log_line("huggingface_hub import failed:\n" + traceback.format_exc())
         return False
+    stop = threading.Event()
+
+    def _report() -> None:
+        while not stop.wait(1.5):
+            _set_progress(_safe_mb(dest), total_mb)
+
+    threading.Thread(target=_report, daemon=True).start()
+    try:
+        snapshot_download(repo_id=MODEL_REPO, local_dir=str(dest))
+        return _model_complete(expected_weight)
+    except Exception:  # noqa: BLE001
+        import traceback
+        _log_line("ERROR: download failed:\n" + traceback.format_exc())
+        return False
+    finally:
+        stop.set()
+
+
+def _cleanup_hf_cache(dest: Path) -> None:
+    """Remove hf_hub's .cache/.incomplete scratch after a verified download so
+    the model dir holds only the final files (and frees the resume scratch)."""
+    for sub in (".cache", ".huggingface"):
+        try:
+            shutil.rmtree(dest / sub, ignore_errors=True)
+        except OSError:
+            pass
+
+
+def _purge_truncated_finals(expected_weight: int) -> None:
+    """Remove a truncated TOP-LEVEL weight file (e.g. a model.safetensors left
+    half-written by a SIGKILLed copy). hf_hub would otherwise see the final file
+    present and SKIP re-downloading it, so the model could never complete. A
+    COMPLETE file (size >= expected) is kept — snapshot_download then no-ops."""
+    if not expected_weight:
+        return
+    p = model_path()
+    for f in _WEIGHT_FILES:
+        wf = p / f
+        try:
+            if wf.is_file() and wf.stat().st_size < int(expected_weight * 0.99):
+                _log_line(f"removing truncated {f} ({wf.stat().st_size/(1024*1024):.0f} MB "
+                          f"< expected {expected_weight/(1024*1024):.0f} MB) for a clean re-fetch")
+                wf.unlink()
+        except OSError:
+            pass
 
 
 def _download_worker() -> None:
     global _status
+    _log_reset()
+    _log_line(f"=== downloading {MODEL_REPO} ===")
     try:
-        from huggingface_hub import snapshot_download
-    except Exception as exc:  # noqa: BLE001
-        with _lock:
-            _status = {"state": "error", "repo": MODEL_REPO,
-                       "message": f"huggingface_hub not installed: {exc}"}
-        return
+        from . import runtime_manager
+        runtime_manager.ensure_on_path()
+        frozen = runtime_manager.is_frozen()
+    except Exception:  # noqa: BLE001
+        frozen = False
+    dest = model_path()
+    existing = _safe_mb(dest)
+    if existing > 1:
+        _log_line(f"{existing:.0f} MB already present — will resume / verify")
+    total_mb, expected_weight = _fetch_sizes()
+    _purge_truncated_finals(expected_weight)
+    _log_line(f"target={dest}")
+    with _lock:
+        _status = {"state": "downloading", "repo": MODEL_REPO,
+                   "message": f"Downloading {MODEL_REPO}…"}
     try:
-        dest = model_path()
         dest.parent.mkdir(parents=True, exist_ok=True)
-        with _lock:
-            _status = {"state": "downloading", "repo": MODEL_REPO,
-                       "message": f"Downloading {MODEL_REPO}…"}
-        snapshot_download(
-            repo_id=MODEL_REPO,
-            local_dir=str(dest),
-            local_dir_use_symlinks=False,
-        )
+        ok = (_download_supervised(dest, total_mb, expected_weight) if frozen
+              else _download_in_process(dest, total_mb, expected_weight))
+    except Exception:  # noqa: BLE001
+        import traceback
+        _log_line("ERROR:\n" + traceback.format_exc())
+        ok = False
+    if ok and _model_complete(expected_weight):
+        _write_ok_marker()
+        _write_model_info()  # record the resolved HF revision for update checks
+        _cleanup_hf_cache(dest)
+        mb = _safe_mb(dest)
+        _log_line(f"SUCCESS: model installed and verified ({mb:.0f} MB)")
         with _lock:
             _status = {"state": "installed", "repo": MODEL_REPO,
-                       "message": "Model installed."}
+                       "message": f"Model installed ({mb:.0f} MB)."}
         logger.info("AI-detection model installed at %s", dest)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("AI-detection model download failed: %s", exc)
+    else:
+        _log_line("ERROR: download did not complete or is incomplete — see the log above.")
         with _lock:
             _status = {"state": "error", "repo": MODEL_REPO,
-                       "message": f"Download failed: {exc}"}
+                       "message": "Download failed or stalled — see the log below."}
+    try:
+        from . import diagnostics
+        with _lock:
+            st = _status.get("state")
+        diagnostics.record({"backend": "model-download", "outcome": st, "reason": MODEL_REPO})
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def start_download() -> Dict[str, object]:
@@ -185,3 +677,302 @@ def delete_model() -> Dict[str, object]:
             shutil.rmtree(p, ignore_errors=True)
         _status = {"state": "idle", "repo": MODEL_REPO, "message": "Model removed."}
     return model_status()
+
+
+# ── Per-detector install / status / remove (multi-detector layer, R61) ─────
+#
+# These parameterize the on-demand HF download + ``.refcheck_model_info.json``
+# pattern per detector ``key``. They REUSE the same completeness rules
+# (config.json + a real weight artifact + a verified-complete OK marker) as the
+# single-detector path. ``desklib`` delegates to the legacy functions above so
+# its (possibly in-flight) download state and existing on-disk install are
+# preserved byte-for-byte — no behavioural change for existing users.
+
+# Per-key download state (keyed by detector key). Each value mirrors the legacy
+# ``_status`` dict shape. Guarded by ``_lock`` (shared with the legacy state).
+_detector_status: Dict[str, Dict[str, object]] = {}
+_detector_threads: Dict[str, threading.Thread] = {}
+
+
+def _detector_ok_marker(key: str) -> Path:
+    return detector_dir(key) / _OK_MARKER
+
+
+def _detector_info_file(key: str) -> Path:
+    return detector_dir(key) / _MODEL_INFO_FILE
+
+
+def is_detector_installed(key: str) -> bool:
+    """True when detector ``key`` is fully downloaded + verified.
+
+    ``desklib`` reuses the legacy ``is_model_installed()`` so an existing
+    install (which predates this registry) is recognised unchanged.
+    """
+    if (key or "").lower() == DEFAULT_DETECTOR:
+        return is_model_installed()
+    entry = get_detector(key)
+    if not entry:
+        return False
+    p = detector_dir(key)
+    if not (p.is_dir() and (p / "config.json").is_file()):
+        return False
+    if not any((p / f).is_file() for f in _WEIGHT_FILES):
+        return False
+    return (p / _OK_MARKER).is_file()
+
+
+def _detector_complete(key: str, expected_weight_bytes: int) -> bool:
+    p = detector_dir(key)
+    if not (p.is_dir() and (p / "config.json").is_file()):
+        return False
+    weights = [p / f for f in _WEIGHT_FILES if (p / f).is_file()]
+    if not weights:
+        return False
+    try:
+        biggest = max(w.stat().st_size for w in weights)
+    except OSError:
+        return False
+    if expected_weight_bytes > 0:
+        return biggest >= int(expected_weight_bytes * 0.99)
+    return biggest > 50 * 1024 * 1024
+
+
+def detector_status(key: str) -> Dict[str, object]:
+    """Install/download status for ONE detector, including registry metadata.
+
+    Honesty contract: a Tier-2 / non-installable detector reports
+    ``installable: False`` and is NEVER ``installed`` (we don't have a runner),
+    so the FE can show it as unavailable and never offer to run it.
+    """
+    entry = get_detector(key)
+    if not entry:
+        return {"key": key, "state": "unknown", "installed": False,
+                "installable": False, "error": "unknown_detector"}
+    k = str(entry["key"])
+    installable = bool(entry.get("installable"))
+    if k == DEFAULT_DETECTOR:
+        base = model_status()
+        installed = bool(base.get("installed"))
+        state = base.get("state")
+        size = base.get("size_bytes", 0)
+        log = base.get("log", [])
+    else:
+        installed = is_detector_installed(k) if installable else False
+        with _lock:
+            st = _detector_status.get(k, {})
+            state = st.get("state", "idle")
+            log = list(st.get("log", []))[-120:] if isinstance(st.get("log"), list) else []
+        if installed and state not in ("downloading",):
+            state = "installed"
+        size = _dir_size_bytes(detector_dir(k)) if installed else 0
+    return {
+        "key": k,
+        "repo": entry["repo"],
+        "arch": entry["arch"],
+        "head": entry["head"],
+        "tier": entry["tier"],
+        "size_mb": entry["size_mb"],
+        "threshold": entry["threshold"],
+        "license": entry["license"],
+        "raid_note": entry["raid_note"],
+        "label": entry.get("label", k),
+        "heavy": bool(entry.get("heavy")),
+        "installable": installable,
+        "installed": installed,
+        "state": state,
+        "path": str(detector_dir(k)),
+        "size_bytes": size,
+        "deps_available": deps_available(),
+        "log": log,
+    }
+
+
+def registry_status() -> Dict[str, object]:
+    """Full registry + per-detector status for the manager UI / API.
+
+    The default detector is reported first; the order otherwise follows the
+    registry (Tier-1 before Tier-2).
+    """
+    detectors = [detector_status(k) for k in DETECTOR_REGISTRY]
+    return {
+        "default": DEFAULT_DETECTOR,
+        "detectors": detectors,
+        "deps_available": deps_available(),
+    }
+
+
+def _detector_log(key: str, msg: str) -> None:
+    import time
+    stamp = time.strftime("%H:%M:%S")
+    with _lock:
+        st = _detector_status.setdefault(key, {"state": "idle", "log": []})
+        log = st.setdefault("log", [])
+        for line in (str(msg).splitlines() or [""]):
+            log.append(f"{stamp}  {line}")
+        if len(log) > _LOG_CAP:
+            del log[: len(log) - _LOG_CAP]
+
+
+def _fetch_sizes_for(repo: str) -> tuple:
+    try:
+        from huggingface_hub import HfApi
+        info = HfApi().model_info(repo, files_metadata=True)
+        sizes = [(getattr(s, "size", 0) or 0) for s in (info.siblings or [])]
+        total_mb = sum(sizes) / (1024 * 1024)
+        max_weight = max(sizes) if sizes else 0
+        return total_mb, max_weight
+    except Exception:  # noqa: BLE001
+        return 0.0, 0
+
+
+def _resolve_latest_revision_for(repo: str):
+    try:
+        from huggingface_hub import HfApi
+        info = HfApi().model_info(repo)
+        return getattr(info, "sha", None) or getattr(info, "lastModified", None)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _write_detector_info(key: str) -> None:
+    try:
+        import json
+        from datetime import datetime, timezone
+        entry = get_detector(key) or {}
+        info = {
+            "repo": entry.get("repo"),
+            "resolved_revision": _resolve_latest_revision_for(str(entry.get("repo") or "")),
+            "download_timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        _detector_info_file(key).write_text(json.dumps(info))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _detector_download_worker(key: str) -> None:
+    """Background download of a non-default detector via in-process
+    snapshot_download (Xet disabled), mirroring ``_download_in_process``."""
+    entry = get_detector(key)
+    repo = str(entry["repo"])
+    dest = detector_dir(key)
+    _detector_log(key, f"=== downloading {repo} ===")
+    total_mb, expected_weight = _fetch_sizes_for(repo)
+    with _lock:
+        _detector_status[key] = {
+            "state": "downloading",
+            "log": _detector_status.get(key, {}).get("log", []),
+            "message": f"Downloading {repo}…",
+        }
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
+    sys.modules.setdefault("hf_xet", None)
+    ok = False
+    try:
+        from . import runtime_manager
+        runtime_manager.ensure_on_path()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        from huggingface_hub import snapshot_download
+        snapshot_download(repo_id=repo, local_dir=str(dest))
+        ok = _detector_complete(key, expected_weight)
+    except Exception:  # noqa: BLE001
+        import traceback
+        _detector_log(key, "ERROR: download failed:\n" + traceback.format_exc())
+        ok = False
+    with _lock:
+        log = _detector_status.get(key, {}).get("log", [])
+    if ok:
+        try:
+            _detector_ok_marker(key).write_text("ok\n")
+        except OSError:
+            pass
+        _write_detector_info(key)
+        mb = _safe_mb(dest)
+        _detector_log(key, f"SUCCESS: detector installed ({mb:.0f} MB)")
+        with _lock:
+            _detector_status[key] = {"state": "installed", "log": log,
+                                     "message": f"Installed ({mb:.0f} MB)."}
+    else:
+        _detector_log(key, "ERROR: download did not complete — see log.")
+        with _lock:
+            _detector_status[key] = {"state": "error", "log": log,
+                                     "message": "Download failed or incomplete."}
+    try:
+        from . import diagnostics
+        with _lock:
+            stt = _detector_status.get(key, {}).get("state")
+        diagnostics.record({"backend": "detector-download", "outcome": stt,
+                            "reason": f"{key}:{repo}"})
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def start_detector_download(key: str) -> Dict[str, object]:
+    """Start (or report) the background download of detector ``key``.
+
+    Refuses non-installable (Tier-2) detectors honestly — they have no runner,
+    so we never download or mark them installable. ``desklib`` delegates to the
+    legacy ``start_download()`` so its state machine is untouched.
+    """
+    entry = get_detector(key)
+    if not entry:
+        return {"key": key, "state": "error", "error": "unknown_detector",
+                "installable": False}
+    if not entry.get("installable"):
+        return {"key": str(entry["key"]), "state": "unavailable",
+                "installable": False,
+                "message": "This detector is heavy and not runnable in this "
+                           "build; it cannot be installed.",
+                "heavy": bool(entry.get("heavy"))}
+    if not deps_available():
+        return {"key": str(entry["key"]), "state": "error",
+                "error": "deps_not_installed", "installable": True,
+                "message": "Local detection runtime not installed (torch + "
+                           "transformers). Install it first."}
+    k = str(entry["key"])
+    if k == DEFAULT_DETECTOR:
+        start_download()
+        return detector_status(k)
+    if is_detector_installed(k):
+        return detector_status(k)
+    with _lock:
+        st = _detector_status.get(k, {})
+        th = _detector_threads.get(k)
+        if st.get("state") == "downloading" and th and th.is_alive():
+            return detector_status(k)
+        _detector_status[k] = {"state": "downloading",
+                               "log": st.get("log", []),
+                               "message": "Download started."}
+        t = threading.Thread(target=_detector_download_worker, args=(k,), daemon=True)
+        _detector_threads[k] = t
+        t.start()
+    return detector_status(k)
+
+
+def delete_detector(key: str) -> Dict[str, object]:
+    """Remove an installed detector from disk (per-key).
+
+    Refuses while that detector's download is in flight. ``desklib`` delegates
+    to the legacy ``delete_model()``.
+    """
+    entry = get_detector(key)
+    if not entry:
+        return {"key": key, "state": "error", "error": "unknown_detector"}
+    k = str(entry["key"])
+    if k == DEFAULT_DETECTOR:
+        delete_model()
+        return detector_status(k)
+    with _lock:
+        th = _detector_threads.get(k)
+        st = _detector_status.get(k, {})
+        if st.get("state") == "downloading" and th and th.is_alive():
+            return {"key": k, "state": "downloading",
+                    "message": "Cannot remove while a download is in progress."}
+        p = detector_dir(k)
+        if p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+        _detector_status[k] = {"state": "idle", "log": st.get("log", []),
+                               "message": "Detector removed."}
+    return detector_status(k)

--- a/src/refchecker/ai_detection/multi_run.py
+++ b/src/refchecker/ai_detection/multi_run.py
@@ -1,0 +1,333 @@
+"""Multi-detector run + honest side-by-side comparison (R61 / §14, item 2).
+
+Run **one or more** installed Tier-1 detectors over the same manuscript and
+return each detector's OWN verdict, plus a comparison summary computed in plain
+code. There is deliberately **no synthetic "ensemble truth"**: disagreement
+between detectors is surfaced as signal, never averaged away into a single
+fabricated number. An uninstalled / non-installable detector ABSTAINS — it
+never reports a score.
+
+The per-detector result reuses the existing honesty machinery in
+:mod:`base` and :mod:`local_backend`:
+
+* windowed document scoring (mean over >= MIN_WORDS windows),
+* per-detector score→band thresholds (the registry ``threshold``),
+* per-sentence scoring (descriptive, capped, advisory — not a guilt prob).
+
+The comparison summary reports:
+
+* ``per_sentence`` — for each shared sentence, every detector's band + the
+  agreement count (how many detectors landed on the modal band),
+* ``pairwise_agreement`` — for each detector pair, the fraction of shared
+  sentences where their bands matched,
+* ``band_agreement`` — whether the detectors' DOCUMENT bands all matched.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Dict, List, Optional, Sequence
+
+from .base import (
+    AIDetectionResult,
+    BAND_HIGH,
+    BAND_MEDIUM,
+    BAND_LOW,
+    DISCLAIMER,
+    OPERATING_POINT,
+    band_from_probability,
+    band_rank,
+    iter_windows,
+    make_inconclusive,
+    make_unavailable,
+    prepared_text,
+    should_abstain,
+)
+from . import model_manager
+
+logger = logging.getLogger(__name__)
+
+_SENT_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+
+def _band_for_score(score: float, threshold: Optional[float]) -> str:
+    """Band a score using this detector's OWN high threshold.
+
+    Falls back to the shared :func:`band_from_probability` when the registry
+    gives no per-detector threshold. The medium cut is the global default; only
+    the high cut is per-detector (that's the one the registry calibrates).
+    """
+    from .base import MEDIUM_THRESHOLD
+    if threshold is None:
+        return band_from_probability(score)
+    if score >= float(threshold):
+        return BAND_HIGH
+    if score >= MEDIUM_THRESHOLD:
+        return BAND_MEDIUM
+    return BAND_LOW
+
+
+def _document_sentences(body: str, cap: int = 40) -> List[str]:
+    """A bounded list of assessable sentences shared across detectors.
+
+    The SAME sentence set is scored by every detector so the per-sentence
+    agreement view compares like-for-like. Sentences are filtered to a readable
+    length band (mirrors local_backend's _viz sentence filter) and capped so a
+    long document can't explode the per-detector inference budget.
+    """
+    out: List[str] = []
+    seen = set()
+    for s in _SENT_SPLIT.split(body):
+        s = s.strip()
+        if 40 <= len(s) <= 320 and s not in seen:
+            seen.add(s)
+            out.append(s)
+            if len(out) >= cap:
+                break
+    return out
+
+
+def _run_one(key: str, body: str, wc: int, sentences: Sequence[str]) -> Dict:
+    """Score the document + shared sentences with detector ``key``.
+
+    Returns a dict shaped like ``AIDetectionResult.to_dict()`` plus a
+    ``per_sentence`` list (one entry per shared sentence: text, score, band).
+    Abstains (unavailable / inconclusive) honestly — NEVER a fabricated number.
+    """
+    entry = model_manager.get_detector(key)
+    if not entry:
+        d = make_unavailable("unknown_detector", key, wc).to_dict()
+        d["key"] = key
+        d["per_sentence"] = []
+        return d
+    label = str(entry.get("label", key))
+    threshold = entry.get("threshold")
+
+    if not entry.get("installable"):
+        r = make_unavailable("detector_not_runnable", key, wc)
+        d = r.to_dict()
+        d.update({"key": key, "label": label, "tier": entry.get("tier"),
+                  "threshold": threshold, "per_sentence": []})
+        return d
+    if not model_manager.is_detector_installed(key):
+        r = make_unavailable("model_not_installed", key, wc)
+        d = r.to_dict()
+        d.update({"key": key, "label": label, "tier": entry.get("tier"),
+                  "threshold": threshold, "per_sentence": []})
+        return d
+    if not model_manager.deps_available():
+        r = make_unavailable("deps_not_installed", key, wc)
+        d = r.to_dict()
+        d.update({"key": key, "label": label, "tier": entry.get("tier"),
+                  "threshold": threshold, "per_sentence": []})
+        return d
+
+    # Only score windows that independently clear the reliability floors, same
+    # rule as LocalDetectorBackend — keeps equation/citation-dense windows out.
+    kept = [w for w in iter_windows(body) if should_abstain(w) is None]
+    if not kept:
+        r = make_inconclusive("insufficient_signal", key, wc)
+        d = r.to_dict()
+        d.update({"key": key, "label": label, "tier": entry.get("tier"),
+                  "threshold": threshold, "per_sentence": []})
+        return d
+
+    try:
+        from . import local_backend
+        engine = local_backend.load(key)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("detector %s load failed: %s", key, exc)
+        r = make_unavailable("model_load_failed", key, wc, detail=str(exc)[:300])
+        d = r.to_dict()
+        d.update({"key": key, "label": label, "tier": entry.get("tier"),
+                  "threshold": threshold, "per_sentence": []})
+        return d
+
+    try:
+        probs = [float(engine.score(w)) for w in kept]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("detector %s inference failed: %s", key, exc)
+        r = make_unavailable("inference_failed", key, wc, detail=str(exc)[:300])
+        d = r.to_dict()
+        d.update({"key": key, "label": label, "tier": entry.get("tier"),
+                  "threshold": threshold, "per_sentence": []})
+        return d
+
+    doc_score = round(sum(probs) / len(probs), 3)
+    raw_band = _band_for_score(doc_score, threshold)
+    band = raw_band
+    # Same single-window cap as the local backend: a lone high window stays
+    # advisory (medium) so one noisy window never drives a 'high' verdict.
+    if band == BAND_HIGH and len(kept) < 2:
+        band = BAND_MEDIUM
+    surfaced = None if band_rank(band) < band_rank(raw_band) else doc_score
+
+    per_sentence = []
+    for s in sentences:
+        try:
+            sc = round(float(engine.score(s)), 3)
+        except Exception:  # noqa: BLE001
+            continue
+        per_sentence.append({
+            "text": s,
+            "score": sc,
+            "band": _band_for_score(sc, threshold),
+        })
+
+    result = AIDetectionResult(
+        band=band,
+        overall_score=surfaced,
+        confidence="medium",
+        summary=f"{label}: document score {doc_score:.2f} over {len(kept)} windows.",
+        backend_used=f"local:{key}",
+        model_version=f"local:{entry.get('repo')}",
+        operating_point=OPERATING_POINT,
+        word_count=wc,
+        disclaimer=DISCLAIMER,
+    )
+    d = result.to_dict()
+    d.update({
+        "key": key,
+        "label": label,
+        "tier": entry.get("tier"),
+        "threshold": threshold,
+        "per_sentence": per_sentence,
+    })
+    return d
+
+
+def _comparison_summary(results: List[Dict], sentences: List[str]) -> Dict:
+    """Compute agreement metrics across detectors in PLAIN code (no ensemble).
+
+    Only detectors that actually produced a scored band participate; abstaining
+    detectors are excluded from agreement math (they have no verdict to compare).
+    """
+    scored = [r for r in results if r.get("band") in (BAND_LOW, BAND_MEDIUM, BAND_HIGH)]
+    keys = [r["key"] for r in scored]
+
+    # Document-level band agreement.
+    doc_bands = {r["key"]: r["band"] for r in scored}
+    band_agreement = len(set(doc_bands.values())) <= 1 if scored else False
+
+    # Per-sentence agreement: align each detector's per-sentence band by text.
+    by_text: Dict[str, Dict[str, str]] = {}
+    for r in scored:
+        for ps in r.get("per_sentence", []):
+            by_text.setdefault(ps["text"], {})[r["key"]] = ps["band"]
+
+    per_sentence = []
+    for s in sentences:
+        bands = by_text.get(s)
+        if not bands:
+            continue
+        # Modal band + how many detectors landed on it.
+        counts: Dict[str, int] = {}
+        for b in bands.values():
+            counts[b] = counts.get(b, 0) + 1
+        modal_band = max(counts, key=lambda b: counts[b])
+        agreement_count = counts[modal_band]
+        per_sentence.append({
+            "text": s,
+            "bands": dict(bands),                 # {detector_key: band}
+            "modal_band": modal_band,
+            "agreement_count": agreement_count,   # how many agree on the modal band
+            "detector_count": len(bands),
+            "unanimous": agreement_count == len(bands),
+        })
+
+    # Pairwise agreement: fraction of shared sentences where the pair's bands match.
+    pairwise = []
+    for i in range(len(keys)):
+        for j in range(i + 1, len(keys)):
+            a, b = keys[i], keys[j]
+            shared = matched = 0
+            for s in sentences:
+                bands = by_text.get(s, {})
+                if a in bands and b in bands:
+                    shared += 1
+                    if bands[a] == bands[b]:
+                        matched += 1
+            pairwise.append({
+                "pair": [a, b],
+                "shared_sentences": shared,
+                "matched": matched,
+                "agreement": round(matched / shared, 3) if shared else None,
+            })
+
+    return {
+        "detectors_compared": keys,
+        "document_bands": doc_bands,
+        "band_agreement": band_agreement,
+        "per_sentence": per_sentence,
+        "pairwise_agreement": pairwise,
+    }
+
+
+def run_detectors(text_or_pages, keys: Sequence[str]) -> Dict:
+    """Run the selected detectors over ``text_or_pages`` and compare them.
+
+    ``text_or_pages`` is the manuscript body string (or a list of page strings,
+    which are joined). ``keys`` is the ordered list of detector keys to run.
+
+    Returns::
+
+        {
+          "detectors": [ <per-detector result dict>, ... ],
+          "comparison": { ...agreement summary... },
+          "word_count": int,
+          "disclaimer": str,
+        }
+
+    Honesty contract: an uninstalled / non-installable detector appears in
+    ``detectors`` with an "unavailable" band and NO score — it is never given a
+    fabricated number and never participates in the agreement math.
+    """
+    if isinstance(text_or_pages, (list, tuple)):
+        text = "\n\n".join(str(p) for p in text_or_pages if p)
+    else:
+        text = str(text_or_pages or "")
+
+    body, wc = prepared_text(text)
+    # De-dupe keys while preserving order; drop empties.
+    seen = set()
+    ordered_keys: List[str] = []
+    for k in (keys or []):
+        k = (k or "").strip().lower()
+        if k and k not in seen:
+            seen.add(k)
+            ordered_keys.append(k)
+    if not ordered_keys:
+        ordered_keys = [model_manager.DEFAULT_DETECTOR]
+
+    abstain_reason = should_abstain(body)
+    sentences = [] if abstain_reason else _document_sentences(body)
+
+    results: List[Dict] = []
+    for key in ordered_keys:
+        if abstain_reason:
+            # Body itself is below the reliability floor → every detector
+            # abstains identically (honest, no fabricated numbers).
+            entry = model_manager.get_detector(key)
+            r = (make_unavailable("no_body_text", key, wc)
+                 if abstain_reason == "no_body_text"
+                 else make_inconclusive(abstain_reason, key, wc))
+            d = r.to_dict()
+            d.update({
+                "key": key,
+                "label": str((entry or {}).get("label", key)),
+                "tier": (entry or {}).get("tier"),
+                "threshold": (entry or {}).get("threshold"),
+                "per_sentence": [],
+            })
+            results.append(d)
+        else:
+            results.append(_run_one(key, body, wc, sentences))
+
+    comparison = _comparison_summary(results, sentences)
+    return {
+        "detectors": results,
+        "comparison": comparison,
+        "word_count": wc,
+        "disclaimer": DISCLAIMER,
+    }

--- a/src/refchecker/ai_detection/runtime_manager.py
+++ b/src/refchecker/ai_detection/runtime_manager.py
@@ -1,0 +1,510 @@
+"""Install / status for the local-detector inference runtime (optional deps).
+
+The local detector needs an inference runtime that is deliberately **not**
+bundled (to keep the desktop sidecar small): ``transformers`` plus a backend
+(``torch`` — required for the default ``desklib`` model, which ships
+safetensors only — or ``onnxruntime`` for an ONNX export).
+
+This module installs that runtime, on demand, into a writable per-user
+directory via ``pip --target`` and prepends that directory to ``sys.path`` so
+the frozen/desktop interpreter (and a normal source install) can import the
+freshly-installed packages without a restart.
+
+Why ``--target`` rather than a plain ``pip install``:
+* In the PyInstaller desktop bundle there is no writable ``site-packages``; a
+  ``--target`` dir under the app-data directory is the only place we can write.
+* It keeps the heavy ML deps out of the base environment / bundle entirely.
+
+Install runs in a background thread and reports progress through a module-level
+status dict (poll ``runtime_status``), mirroring :mod:`model_manager`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import logging
+import os
+import sys
+import threading
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Package sets per variant. transformers is always needed; the backend differs.
+# "torch" is the default because the bundled desklib model ships safetensors
+# only (no model.onnx), so onnxruntime alone cannot run it.
+_VARIANTS: Dict[str, List[str]] = {
+    "torch": ["torch", "transformers", "huggingface_hub"],
+    "onnx": ["onnxruntime", "transformers", "huggingface_hub"],
+}
+DEFAULT_VARIANT = "torch"
+
+# Standalone pip zipapp, used only when the (frozen) interpreter has no
+# importable ``pip`` of its own. Pinned to the version-agnostic redirect.
+_PIP_PYZ_URL = "https://bootstrap.pypa.io/pip/pip.pyz"
+
+_lock = threading.Lock()
+_status: Dict[str, object] = {"state": "idle", "message": "", "variant": None}
+_thread: Optional[threading.Thread] = None
+_on_path_done = False
+
+# Rolling install/diagnostic log (newest-last), streamed live to the UI debugger
+# so a failing desktop install shows the real pip output instead of failing
+# silently. Capped so it can't grow without bound.
+_LOG_CAP = 400
+_log: List[str] = []
+
+
+def _log_line(msg: str) -> None:
+    import time
+    stamp = time.strftime("%H:%M:%S")
+    with _lock:
+        for line in (str(msg).splitlines() or [""]):
+            _log.append(f"{stamp}  {line}")
+        if len(_log) > _LOG_CAP:
+            del _log[: len(_log) - _LOG_CAP]
+
+
+def _log_reset() -> None:
+    with _lock:
+        _log.clear()
+
+
+def get_log(limit: int = 160) -> List[str]:
+    with _lock:
+        return _log[-limit:]
+
+
+class _LogWriter(io.TextIOBase):
+    """File-like sink that streams written text into the install log live (used
+    to capture in-process pip output as it happens)."""
+
+    def write(self, s):  # noqa: D401
+        if s:
+            _log_line(s.rstrip("\n"))
+        return len(s)
+
+    def flush(self):
+        return None
+
+
+def is_frozen() -> bool:
+    """True when running inside a PyInstaller (desktop sidecar) bundle."""
+    return bool(getattr(sys, "frozen", False)) or hasattr(sys, "_MEIPASS")
+
+
+def runtime_dir() -> Path:
+    """Writable directory the optional runtime is installed into."""
+    env = os.environ.get("REFCHECKER_AI_DETECTION_RUNTIME_DIR")
+    if env:
+        return Path(env)
+    data = os.environ.get("REFCHECKER_DATA_DIR")
+    if data:
+        return Path(data) / "ai-detection-runtime"
+    cache = os.environ.get("REFCHECKER_CACHE_DIR")
+    if cache:
+        return Path(cache) / "ai-detection-runtime"
+    return Path.home() / ".cache" / "refchecker" / "ai-detection-runtime"
+
+
+# ── Frozen-bundle import-shadowing fix ─────────────────────────────────────
+# In the PyInstaller bundle, the FrozenImporter (front of sys.meta_path) holds
+# PARTIAL copies of packages the base app imported — e.g. a `tqdm` WITHOUT
+# `tqdm/auto.py`, because the server only does `from tqdm import tqdm`. That
+# partial shadows the COMPLETE copy pip installs into the --target dir, so the
+# runtime fails with `No module named 'tqdm.auto'`. Fix (designed + proof-tested
+# via a workflow): a front-of-meta_path finder that resolves an ALLOWLIST of
+# ML-runtime top-level packages from the target dir, plus eviction of the stale
+# pre-cached `tqdm` (the server imports it at startup, so it's already in
+# sys.modules before the finder exists — a finder alone would be bypassed).
+# Default-deny: the live server's own packages (httpx/pydantic/certifi/...) are
+# never claimed, so its import resolution is unchanged.
+_ML_ALLOWLIST = frozenset({
+    "torch", "transformers", "huggingface_hub", "tqdm", "tokenizers",
+    "safetensors", "regex", "sympy", "networkx", "filelock", "fsspec",
+    "numpy", "accelerate", "hf_xet", "mpmath", "annotated_doc", "typer",
+    "rich", "markdown_it", "mdurl", "pygments", "shellingham", "onnxruntime",
+})
+
+_finder = None  # singleton meta-path finder (installed once)
+
+
+class _RuntimeTargetFinder:
+    """MetaPathFinder resolving only allowlisted TOP-LEVEL names from the
+    runtime --target dir, overriding PyInstaller's FrozenImporter. It claims
+    just the top-level name; submodules (tqdm.auto) then follow the now
+    target-rooted parent __path__ via the normal machinery."""
+
+    def __init__(self, target: str, owned):
+        self.target = target
+        self.owned = frozenset(owned)
+
+    def find_spec(self, fullname, path=None, target=None):
+        top = fullname.split(".", 1)[0]
+        if fullname != top or top not in self.owned:
+            return None  # submodule, or not an ML package → default deny
+        try:
+            from importlib.machinery import PathFinder
+            return PathFinder.find_spec(fullname, [self.target], target)
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def _activate_runtime_shadowing(target: str) -> None:
+    """Install the finder (once) and evict the stale pre-cached partial tqdm."""
+    global _finder
+    try:
+        present = set()
+        for entry in os.listdir(target):
+            name = entry[:-3] if entry.endswith(".py") else entry.split("-", 1)[0]
+            present.add(name.split(".", 1)[0])
+    except OSError:
+        return
+    owned = frozenset(_ML_ALLOWLIST & present)
+    if not owned:
+        return
+    # Atomic under the lock: the install worker thread and the UI status-poll
+    # request threads can both reach here, and a half-evicted tqdm observed by a
+    # concurrent import would raise. Only cheap ops here (no heavy imports).
+    with _lock:
+        if _finder is None:
+            _finder = _RuntimeTargetFinder(target, owned)
+            sys.meta_path.insert(0, _finder)
+            # Evict the stale partial tqdm (imported from the bundle at server
+            # startup) so it re-resolves complete from the target. Only the
+            # pure-Python tqdm — NEVER a loaded C-extension (numpy), whose
+            # re-init would crash — and only copies not already from the target.
+            for name in [m for m in list(sys.modules) if m == "tqdm" or m.startswith("tqdm.")]:
+                mod = sys.modules.get(name)
+                if not (getattr(mod, "__file__", "") or "").startswith(target):
+                    del sys.modules[name]
+        else:
+            _finder.target = target
+            _finder.owned = owned
+        importlib.invalidate_caches()
+
+
+def ensure_on_path() -> None:
+    """Make an installed --target runtime importable.
+
+    Source installs: prepend the target to sys.path (the user installed there,
+    so it should win). Frozen desktop bundle: APPEND the target — so the bundle
+    (sys.path[0], set by server_entry) stays ahead for the server's own shared
+    deps — and activate the import-shadowing fix so ML packages resolve from the
+    target over the bundle's partial frozen copies. Idempotent; a no-op until
+    the dir exists, so source / never-installed setups are unaffected.
+    """
+    global _on_path_done
+    d = runtime_dir()
+    try:
+        exists = d.is_dir()
+    except OSError:
+        exists = False
+    if not exists:
+        return
+    s = str(d)
+    if is_frozen():
+        if s not in sys.path:
+            sys.path.append(s)
+            importlib.invalidate_caches()
+        _activate_runtime_shadowing(s)
+    else:
+        if s not in sys.path:
+            sys.path.insert(0, s)
+            importlib.invalidate_caches()
+    _on_path_done = True
+
+
+# ── pip invocation ─────────────────────────────────────────────────────────
+
+def _torch_index_args(variant: str) -> List[str]:
+    """Pull the CPU-only torch wheel on Linux/Windows (the default PyPI torch
+    wheel there is the multi-hundred-MB CUDA build). macOS wheels are CPU."""
+    if variant == "torch" and sys.platform.startswith(("linux", "win")):
+        return ["--index-url", "https://download.pytorch.org/whl/cpu",
+                "--extra-index-url", "https://pypi.org/simple"]
+    return []
+
+
+def _pip_argv(variant: str) -> List[str]:
+    argv = ["install", "--no-input", "--disable-pip-version-check",
+            "--no-warn-script-location",
+            # --upgrade so a re-install REPLACES existing dirs instead of
+            # skipping them ("Target directory ... already exists"), which would
+            # otherwise leave a half-old/half-new mix that fails to import.
+            "--upgrade", "--target", str(runtime_dir())]
+    # In the frozen bundle there is no compiler / usable build environment, so
+    # never let pip fall back to building an sdist from source; and skip the
+    # cache dir (the bundle's HOME may be read-only / unexpected).
+    if is_frozen():
+        argv += ["--only-binary=:all:", "--no-cache-dir"]
+    argv += _torch_index_args(variant)
+    argv += _VARIANTS[variant]
+    return argv
+
+
+def _clean_target() -> None:
+    """Empty the runtime dir (keep a downloaded pip.pyz) before a fresh install.
+
+    A prior interrupted/failed install leaves a partial tree that ``pip
+    --target`` skips rather than repairs; wiping guarantees a coherent install.
+    """
+    import shutil
+    d = runtime_dir()
+    if not d.is_dir():
+        return
+    _log_line("clearing previous runtime dir for a clean install")
+    for child in d.iterdir():
+        if child.name == "pip.pyz":
+            continue
+        try:
+            shutil.rmtree(child) if child.is_dir() else child.unlink()
+        except OSError as exc:  # noqa: PERF203
+            _log_line(f"could not remove {child.name}: {exc}")
+
+
+def _verbose_import_check() -> Tuple[bool, str]:
+    """Try to import the runtime and return the REAL traceback on failure, so
+    a 'pip succeeded but not importable' case shows why (not a silent retry)."""
+    ensure_on_path()
+    importlib.invalidate_caches()
+    errs: List[str] = []
+    for backend in ("torch", "onnxruntime"):
+        try:
+            importlib.import_module(backend)
+            importlib.import_module("transformers")
+            # Probe the exact submodule a partial frozen tqdm would shadow, so a
+            # shadowing regression fails loudly here, not at first detection.
+            importlib.import_module("tqdm.auto")
+            return True, ""
+        except Exception:  # noqa: BLE001
+            import traceback
+            errs.append(f"--- import {backend} + transformers failed ---\n"
+                        + traceback.format_exc())
+    return False, "\n".join(errs)
+
+
+def _run_pip_subprocess(argv: List[str]) -> bool:
+    """Run ``{sys.executable} -m pip`` — the clean path for source installs.
+
+    Streams pip's output into the live log so the UI debugger shows progress.
+    """
+    import subprocess
+    cmd = [sys.executable, "-m", "pip", *argv]
+    _log_line("$ " + " ".join(cmd))
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
+    )
+    try:
+        for line in proc.stdout:  # live stream
+            _log_line(line.rstrip("\n"))
+        proc.wait(timeout=3600)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    return proc.returncode == 0
+
+
+def _run_pip_frozen_subprocess(argv: List[str]) -> bool:
+    """Install in the frozen desktop bundle by re-invoking the bundle itself in
+    a hidden ``--pip-install`` mode (handled in ``server_entry``).
+
+    Running pip in a SEPARATE process — rather than in-process inside the live
+    server — is what makes this reliable: the child has a clean ``sys.path`` and
+    no FastAPI/torch already imported, so pip can't half-import torch into the
+    running server and leave it broken. Same interpreter → ABI-matched wheels.
+    Output is streamed back into the live log.
+    """
+    import subprocess
+    cmd = [sys.executable, "--pip-install", *argv]
+    _log_line("$ <app> --pip-install " + " ".join(argv))
+    _log_line("(launching a clean installer subprocess; the one-file bundle "
+              "re-extracts first, so expect ~30s before pip output appears)")
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
+    )
+    try:
+        for line in proc.stdout:
+            _log_line(line.rstrip("\n"))
+        proc.wait(timeout=3600)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    return proc.returncode == 0
+
+
+def run_pip_cli(argv: List[str]) -> int:
+    """Run pip in THIS (clean) process — the bundle's ``--pip-install`` entry.
+
+    Uses an importable ``pip`` if the bundle has one, else the downloaded
+    ``pip.pyz``. Output goes to real stdout so the parent captures it.
+    """
+    import runpy
+    if importlib.util.find_spec("pip") is not None:
+        print("[pip] using bundled pip", flush=True)
+        sys.argv = ["pip", *argv]
+        try:
+            runpy.run_module("pip", run_name="__main__", alter_sys=True)
+            return 0
+        except SystemExit as exc:
+            return int(exc.code or 0)
+    pyz = _ensure_pip_pyz()
+    if pyz is None:
+        print("[pip] could not obtain pip", flush=True)
+        return 1
+    print("[pip] using downloaded pip.pyz", flush=True)
+    sys.argv = ["pip", *argv]
+    try:
+        runpy.run_path(str(pyz), run_name="__main__")
+        return 0
+    except SystemExit as exc:
+        return int(exc.code or 0)
+
+
+def _ensure_pip_pyz() -> Optional[Path]:
+    """Download the standalone pip zipapp into the runtime dir (once)."""
+    dest = runtime_dir() / "pip.pyz"
+    if dest.is_file() and dest.stat().st_size > 0:
+        return dest
+    try:
+        import urllib.request
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _log_line(f"Downloading pip from {_PIP_PYZ_URL}…")
+        with urllib.request.urlopen(_PIP_PYZ_URL, timeout=60) as resp:  # noqa: S310
+            data = resp.read()
+        dest.write_bytes(data)
+        _log_line(f"pip.pyz downloaded ({len(data)} bytes)")
+        return dest
+    except Exception as exc:  # noqa: BLE001
+        _log_line(f"pip download failed: {exc}")
+        return None
+
+
+def _run_pip(argv: List[str]) -> bool:
+    if is_frozen():
+        return _run_pip_frozen_subprocess(argv)
+    return _run_pip_subprocess(argv)
+
+
+# ── status / install ───────────────────────────────────────────────────────
+
+def deps_available() -> bool:
+    """Whether an inference runtime (onnxruntime OR torch, + transformers) is
+    importable — after making sure an installed --target runtime is on path."""
+    ensure_on_path()
+    for backend in ("onnxruntime", "torch"):
+        try:
+            importlib.import_module(backend)
+            importlib.import_module("transformers")
+            return True
+        except Exception:  # noqa: BLE001
+            continue
+    return False
+
+
+def installed_variant() -> Optional[str]:
+    """Which backend is importable, if any ('torch' preferred for desklib)."""
+    ensure_on_path()
+    try:
+        importlib.import_module("transformers")
+    except Exception:  # noqa: BLE001
+        return None
+    for name, variant in (("torch", "torch"), ("onnxruntime", "onnx")):
+        try:
+            importlib.import_module(name)
+            return variant
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+def runtime_status() -> Dict[str, object]:
+    with _lock:
+        state = _status.get("state")
+        message = _status.get("message", "")
+        variant = _status.get("variant")
+        log = list(_log[-160:])
+    available = deps_available()
+    if available and state != "installing":
+        state = "installed"
+    return {
+        "state": state,
+        "message": message,
+        "deps_available": available,
+        "installed_variant": installed_variant(),
+        "installing_variant": variant,
+        "default_variant": DEFAULT_VARIANT,
+        "variants": list(_VARIANTS.keys()),
+        "is_frozen": is_frozen(),
+        "target": str(runtime_dir()),
+        "log": log,
+    }
+
+
+def _install_worker(variant: str) -> None:
+    global _status
+    try:
+        _log_line(f"=== installing '{variant}' runtime ===")
+        _log_line(f"frozen={is_frozen()} python={sys.version.split()[0]} "
+                  f"platform={sys.platform} executable={sys.executable}")
+        _log_line(f"target={runtime_dir()}")
+        runtime_dir().mkdir(parents=True, exist_ok=True)
+        _clean_target()
+        ok = _run_pip(_pip_argv(variant))
+        # Make the just-installed packages importable in-process so the next
+        # check / status poll sees them without a restart, then VERIFY they
+        # actually import — a pip exit 0 that still can't be imported (ABI
+        # mismatch, partial install) must surface as an error WITH the real
+        # traceback, not a false "installed" that makes the UI poll forever.
+        importable, import_err = _verbose_import_check()
+        _log_line(f"pip ok={ok} runtime_importable={importable}")
+        if ok and importable:
+            _log_line(f"SUCCESS: {variant} runtime installed and importable")
+            with _lock:
+                _status = {"state": "installed", "variant": variant,
+                           "message": f"Installed {variant} runtime."}
+            logger.info("AI-detection runtime (%s) installed at %s", variant, runtime_dir())
+        elif ok:
+            _log_line("ERROR: pip reported success but the runtime cannot be imported:")
+            _log_line(import_err or "(no import error captured)")
+            with _lock:
+                _status = {"state": "error", "variant": variant,
+                           "message": ("Installed, but the runtime still isn't importable. "
+                                       "See the install log below for the import error.")}
+            logger.warning("AI-detection runtime installed but not importable")
+        else:
+            _log_line("ERROR: pip install failed")
+            with _lock:
+                _status = {"state": "error", "variant": variant,
+                           "message": "Install failed — see the install log below."}
+            logger.warning("AI-detection runtime install failed")
+    except Exception as exc:  # noqa: BLE001
+        import traceback
+        _log_line("CRASH:\n" + traceback.format_exc())
+        logger.warning("AI-detection runtime install crashed: %s", exc)
+        with _lock:
+            _status = {"state": "error", "variant": variant,
+                       "message": f"Install crashed: {exc}"}
+
+
+def start_install(variant: str = DEFAULT_VARIANT) -> Dict[str, object]:
+    """Kick off a background runtime install (idempotent while one runs)."""
+    global _thread, _status
+    variant = (variant or DEFAULT_VARIANT).lower()
+    if variant not in _VARIANTS:
+        variant = DEFAULT_VARIANT
+    if deps_available():
+        return runtime_status()
+    with _lock:
+        if _status.get("state") == "installing" and _thread and _thread.is_alive():
+            return dict(_status, **{"deps_available": False})
+    _log_reset()  # fresh log per install attempt (own lock — keep out of the block above)
+    with _lock:
+        _status = {"state": "installing", "variant": variant,
+                   "message": f"Installing {variant} runtime…"}
+        _thread = threading.Thread(target=_install_worker, args=(variant,), daemon=True)
+        _thread.start()
+    return runtime_status()

--- a/tests/unit/test_ai_detection.py
+++ b/tests/unit/test_ai_detection.py
@@ -29,6 +29,46 @@ def test_abstain_too_short():
     assert base.should_abstain("only a few words here") == "too_short"
 
 
+def test_strip_nonbody_removes_journal_boilerplate():
+    body = ("This systematic review examined the prevalence of hip and knee "
+            "osteoarthritis across European populations using pooled random "
+            "effects meta analysis of observational studies. ") * 40
+    text = (
+        "RESEARCH Open Access © The Author(s) 2026. This article is licensed "
+        "under a Creative Commons Attribution-NonCommercial license.\n"
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/. "
+        "https://doi.org/10.1186/s12891-026-09493-7\n"
+        "*Correspondence: Ioannis Christofides i.christofides@umcg.nl Full list "
+        "of author information is available at the end of the article\n"
+        "Abstract\nIntroduction Osteoarthritis is a leading cause of disability. "
+        + body +
+        "\nKeywords Osteoarthritis, Hip, Knee, Prevalence, Europe\n"
+        "References\n1. Smith J. Prevalence of OA. J Bone Joint Surg. 2020;12:33.\n"
+    )
+    cleaned = base.strip_nonbody(text)
+    low = cleaned.lower()
+    assert "creative commons" not in low and "creativecommons" not in low
+    assert "correspondence" not in low and "@umcg" not in low
+    assert "doi.org" not in low
+    assert "keywords" not in low
+    assert "j bone joint surg" not in cleaned  # reference list dropped
+    assert "©" not in cleaned             # copyright dropped
+    assert "systematic review examined the prevalence" in cleaned  # body kept
+
+
+def test_strip_nonbody_keeps_short_or_odd_text_intact():
+    # No abstract/refs/boilerplate and below the body floor -> never gutted.
+    note = "A brief methodological note on the sampling frame. " * 6
+    assert base.strip_nonbody(note).strip() == note.strip()
+
+
+def test_abstain_no_body_text_distinct_from_too_short():
+    # Empty body (e.g. refs read from a .bbl/.bib) is reported distinctly so the
+    # UI doesn't claim the text is merely "too short".
+    assert base.should_abstain("") == "no_body_text"
+    assert base.should_abstain("   ") == "no_body_text"
+
+
 def test_abstain_technical_section():
     math_heavy = "x = 3.14 + alpha^2 / beta - gamma * 2 == 0 ; " * 80
     assert base.should_abstain(math_heavy) == "technical_section"
@@ -43,6 +83,23 @@ def test_windows_clear_reliability_floor():
     windows = base.iter_windows(LONG_PROSE)
     assert windows
     assert all(base.count_words(w) >= base.MIN_WORDS for w in windows)
+
+
+def test_suspect_span_carries_model_score():
+    # Spans must surface the per-window model score + neighbour agreement so the
+    # UI can show "model score 0.97" per passage (additive, never a guilt prob).
+    from refchecker.ai_detection.local_backend import _agreeing_spans
+    probs = [0.97, 0.99, 0.95]
+    windows = ['window one ' * 40, 'window two ' * 40, 'window three ' * 40]
+    spans = _agreeing_spans(windows, probs, [0, 1, 2])
+    assert spans, 'three adjacent high windows should yield corroborated spans'
+    d = spans[1].to_dict()
+    assert d['model_score'] == 0.99
+    assert d['neighbour_agreement_count'] == 2   # both neighbours agree
+    assert d['confidence_method'] == 'multi_window_agreement'
+    assert '0.99' in d['reason']
+    # Back-compat: the dict always carries the keys (None when not set).
+    assert 'model_score' in base.SuspectSpan(quote='x').to_dict()
 
 
 def test_combine_bands_is_conservative():
@@ -63,7 +120,13 @@ def test_clamp_only_lowers_severity():
     assert base.clamp_not_above("low", "medium") == "low"
 
 
-def test_local_backend_unavailable_without_model():
+def test_local_backend_unavailable_without_model(monkeypatch):
+    # Force the "no model" precondition so this tests the graceful-degradation
+    # contract on every host — including dev machines that happen to have the
+    # desklib weights cached under ~/.cache/refchecker (otherwise the backend
+    # would actually score the text and return a real band).
+    from refchecker.ai_detection import model_manager
+    monkeypatch.setattr(model_manager, "is_model_installed", lambda: False)
     r = run_detection(LONG_PROSE, title="t", backend="local")
     assert r.band == base.BAND_UNAVAILABLE
     assert r.abstain_reason in ("model_not_installed", "deps_not_installed")
@@ -240,3 +303,235 @@ def test_record_detection_usage_attributes_to_check_and_flow():
     assert "ai_detection" in snap["by_flow"]
     assert snap["by_flow"]["ai_detection"]["input_tokens"] == 2500
     assert round(snap["cost_usd"], 4) == 0.1
+
+
+# ── runtime_manager: optional inference-runtime install (no network) ────────
+
+import sys as _sys
+import sys
+import importlib
+
+from refchecker.ai_detection import runtime_manager as _rt
+
+
+def test_runtime_dir_prefers_explicit_then_data_then_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path / "rt"))
+    monkeypatch.setenv("REFCHECKER_DATA_DIR", str(tmp_path / "data"))
+    assert _rt.runtime_dir() == tmp_path / "rt"
+    monkeypatch.delenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", raising=False)
+    assert _rt.runtime_dir() == tmp_path / "data" / "ai-detection-runtime"
+    monkeypatch.delenv("REFCHECKER_DATA_DIR", raising=False)
+    monkeypatch.setenv("REFCHECKER_CACHE_DIR", str(tmp_path / "cache"))
+    assert _rt.runtime_dir() == tmp_path / "cache" / "ai-detection-runtime"
+
+
+def test_pip_argv_torch_targets_runtime_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    argv = _rt._pip_argv("torch")
+    assert argv[0] == "install"
+    assert "--no-input" in argv and "--target" in argv
+    assert argv[argv.index("--target") + 1] == str(tmp_path)
+    assert "torch" in argv and "transformers" in argv
+
+
+def test_pip_argv_cpu_torch_index_off_mac(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setattr(_rt.sys, "platform", "linux")
+    assert "https://download.pytorch.org/whl/cpu" in _rt._pip_argv("torch")
+    # the onnx variant never pulls the torch index
+    assert "https://download.pytorch.org/whl/cpu" not in _rt._pip_argv("onnx")
+
+
+def test_pip_argv_frozen_forces_binary_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setattr(_rt, "is_frozen", lambda: True)
+    assert "--only-binary=:all:" in _rt._pip_argv("torch")
+
+
+def test_ensure_on_path_noop_when_missing_then_adds_once(monkeypatch, tmp_path):
+    target = tmp_path / "rt"
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(target))
+    s = str(target)
+    assert s not in _sys.path
+    _rt.ensure_on_path()              # dir absent → no-op
+    assert s not in _sys.path
+    target.mkdir()
+    try:
+        _rt.ensure_on_path()
+        assert _sys.path[0] == s
+        _rt.ensure_on_path()          # idempotent
+        assert _sys.path.count(s) == 1
+    finally:
+        while s in _sys.path:
+            _sys.path.remove(s)
+
+
+def test_runtime_status_shape(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    st = _rt.runtime_status()
+    for k in ("deps_available", "installed_variant", "default_variant",
+              "variants", "is_frozen", "target"):
+        assert k in st
+    assert st["default_variant"] == "torch"
+    assert set(st["variants"]) == {"torch", "onnx"}
+
+
+def test_start_install_short_circuits_when_runtime_present(monkeypatch, tmp_path):
+    # When deps are already importable, start_install must NOT spawn pip — it
+    # normalizes a bogus variant and returns status without side effects.
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setattr(_rt, "deps_available", lambda: True)
+    res = _rt.start_install("bogus")
+    assert res["deps_available"] is True
+
+
+def test_runtime_status_includes_live_log(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    _rt._log_reset()
+    _rt._log_line("hello-debug-line")
+    st = _rt.runtime_status()
+    assert isinstance(st.get("log"), list)
+    assert any("hello-debug-line" in line for line in st["log"])
+
+
+def test_log_writer_streams_into_buffer():
+    _rt._log_reset()
+    w = _rt._LogWriter()
+    w.write("downloading torch...\n")
+    assert any("downloading torch" in line for line in _rt.get_log())
+
+
+def test_diagnostics_ring_buffer_newest_first():
+    from refchecker.ai_detection import diagnostics
+    diagnostics.clear()
+    diagnostics.record({"backend": "local", "outcome": "low"})
+    diagnostics.record({"backend": "api", "outcome": "high"})
+    evs = diagnostics.events()
+    assert evs[0]["backend"] == "api" and evs[1]["backend"] == "local"
+    assert all("ts" in e for e in evs)
+
+
+def test_clean_target_wipes_but_keeps_pip_pyz(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    (tmp_path / "torch").mkdir()
+    (tmp_path / "junk.txt").write_text("x")
+    (tmp_path / "pip.pyz").write_bytes(b"PK")
+    _rt._clean_target()
+    assert not (tmp_path / "torch").exists()
+    assert not (tmp_path / "junk.txt").exists()
+    assert (tmp_path / "pip.pyz").exists()  # the downloaded pip is preserved
+
+
+def test_pip_argv_has_upgrade_and_cli_entry_exists(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_RUNTIME_DIR", str(tmp_path))
+    assert "--upgrade" in _rt._pip_argv("torch")  # re-install replaces, not skips
+    assert callable(_rt.run_pip_cli)               # bundle --pip-install entry
+
+
+def test_runtime_finder_overrides_partial_shadow(tmp_path):
+    """Reproduce the PyInstaller partial-shadow (a `pkg` with no `pkg/auto.py`
+    pre-cached, mimicking the frozen bundle) and prove the finder + sys.modules
+    eviction make the complete runtime copy win so `pkg.auto` resolves."""
+    pkg = "_rcshadowpkg"
+    bundle, runtime = tmp_path / "bundle", tmp_path / "runtime"
+    (bundle / pkg).mkdir(parents=True)
+    (bundle / pkg / "__init__.py").write_text("VER = 'bundle'\n")        # partial: no auto.py
+    (runtime / pkg).mkdir(parents=True)
+    (runtime / pkg / "__init__.py").write_text("VER = 'runtime'\n")
+    (runtime / pkg / "auto.py").write_text("X = 1\n")                    # complete
+
+    finder = None
+    orig_path = list(sys.path)
+    try:
+        # mimic server startup importing the PARTIAL copy first (caches it)
+        sys.path.insert(0, str(bundle))
+        importlib.invalidate_caches()
+        assert importlib.import_module(pkg).VER == "bundle"
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module(pkg + ".auto")  # the shadow bug, reproduced
+
+        # apply the fix exactly as runtime_manager does
+        finder = _rt._RuntimeTargetFinder(str(runtime), frozenset({pkg}))
+        sys.meta_path.insert(0, finder)
+        sys.path.append(str(runtime))               # append, not insert(0)
+        for n in [k for k in list(sys.modules) if k == pkg or k.startswith(pkg + ".")]:
+            del sys.modules[n]
+        importlib.invalidate_caches()
+
+        assert importlib.import_module(pkg).VER == "runtime"   # finder won over the partial
+        importlib.import_module(pkg + ".auto")                 # previously-missing submodule resolves
+    finally:
+        if finder in sys.meta_path:
+            sys.meta_path.remove(finder)
+        for n in [k for k in list(sys.modules) if k == pkg or k.startswith(pkg + ".")]:
+            del sys.modules[n]
+        sys.path[:] = orig_path
+        importlib.invalidate_caches()
+
+
+def test_model_status_includes_log(monkeypatch, tmp_path):
+    from refchecker.ai_detection import model_manager as _mm
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_MODEL_DIR", str(tmp_path))
+    _mm._log_reset()
+    _mm._log_line("hello-model-log")
+    st = _mm.model_status()
+    assert isinstance(st.get("log"), list)
+    assert any("hello-model-log" in line for line in st["log"])
+
+
+def test_model_download_drops_removed_symlinks_kwarg():
+    # local_dir_use_symlinks was REMOVED in huggingface_hub 1.x → it must not be
+    # passed (it raised TypeError and made the download fail silently), and the
+    # worker must make the pip-installed runtime importable first.
+    import inspect
+    from refchecker.ai_detection import model_manager as _mm
+    src = inspect.getsource(_mm._download_worker)
+    assert "local_dir_use_symlinks=" not in src  # the removed kwarg is not passed
+    assert "ensure_on_path" in src
+
+
+def test_model_download_subprocess_and_xet_off():
+    # The desktop download runs in a clean subprocess (xet truly off, set before
+    # huggingface_hub import); the supervisor resumes via re-run rather than
+    # SIGKILLing hf_hub mid-stream (which corrupts resume).
+    import inspect
+    from refchecker.ai_detection import model_manager as _mm
+    assert callable(_mm.run_hf_download_cli)
+    cli = inspect.getsource(_mm.run_hf_download_cli)
+    assert 'HF_HUB_DISABLE_XET' in cli and 'hf_xet' in cli  # xet disabled + blocked
+    sup = inspect.getsource(_mm._download_supervised)
+    assert '--hf-download' in sup and 'resuming' in sup
+
+
+def test_model_installed_requires_completion_marker(monkeypatch, tmp_path):
+    # A weight file that merely EXISTS must not count as installed — only after
+    # the verified-complete marker is written (guards against truncated partials).
+    from refchecker.ai_detection import model_manager as _mm
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_MODEL_DIR", str(tmp_path))
+    d = _mm.model_path()
+    d.mkdir(parents=True)
+    (d / "config.json").write_text("{}")
+    (d / "model.safetensors").write_bytes(b"x" * (60 * 1024 * 1024))  # 60 MB "weight"
+    assert _mm.is_model_installed() is False          # no marker → not installed
+    assert _mm._model_complete(0) is True             # 60 MB passes the no-expected floor
+    assert _mm._model_complete(200 * 1024 * 1024) is False  # but not vs a 200 MB expected
+    _mm._write_ok_marker()
+    assert _mm.is_model_installed() is True            # marker present → installed
+
+
+def test_runtime_finder_default_deny(tmp_path):
+    # non-allowlisted names and submodules are never claimed (server untouched)
+    f = _rt._RuntimeTargetFinder(str(tmp_path), frozenset({"torch"}))
+    assert f.find_spec("httpx") is None      # not allowlisted → server keeps its copy
+    assert f.find_spec("torch.nn") is None    # submodule → follows parent __path__
+    assert "tqdm" in _rt._ML_ALLOWLIST and "httpx" not in _rt._ML_ALLOWLIST
+
+
+def test_run_detection_records_a_diagnostic_event():
+    from refchecker.ai_detection import diagnostics
+    diagnostics.clear()
+    # unknown backend → graceful unavailable, and still recorded
+    run_detection("some text", backend="nope-not-real")
+    evs = diagnostics.events()
+    assert evs and evs[0]["backend"] == "nope-not-real"
+    assert evs[0]["outcome"] in ("unavailable", "error")

--- a/tests/unit/test_detector_registry.py
+++ b/tests/unit/test_detector_registry.py
@@ -1,0 +1,351 @@
+"""Unit tests for the multi-detector registry + multi-run compare API (R61/I1).
+
+Covers, with NO network and NO real ML weights:
+
+* registry shape + honesty invariants (Tier-2 heavy detectors are not
+  installable / never selectable to run),
+* per-detector install / status / remove using a mocked HF snapshot_download,
+* per-arch head selection (the registry's ``head`` field drives the loader),
+* multi-run aggregation + per-sentence agreement + pairwise-agreement math,
+* uninstalled / non-installable detectors ABSTAIN (never a fabricated number),
+* backward-compat: the default 'desklib' key delegates to the legacy
+  single-detector functions and shares its on-disk path.
+"""
+
+import sys
+
+import pytest
+
+from refchecker.ai_detection import model_manager as mm
+from refchecker.ai_detection import multi_run
+
+
+# ── Registry shape + honesty invariants ────────────────────────────────────
+
+def test_registry_has_required_tier1_detectors():
+    reg = mm.DETECTOR_REGISTRY
+    for key in ("desklib", "superannotate", "e5-small-lora", "mage"):
+        assert key in reg, f"missing Tier-1 detector {key}"
+        e = reg[key]
+        assert e["tier"] == 1
+        assert e["installable"] is True
+        assert e["heavy"] is False
+        # Real metadata must be present (no None placeholders for size/license).
+        assert isinstance(e["size_mb"], (int, float)) and e["size_mb"] > 0
+        assert e["license"] and isinstance(e["license"], str)
+        assert e["repo"] and e["raid_note"]
+
+
+def test_default_detector_is_desklib_and_repo_backward_compatible():
+    assert mm.DEFAULT_DETECTOR == "desklib"
+    # The desklib registry entry's repo must equal the legacy MODEL_REPO const,
+    # and its on-disk dir must equal the legacy model_path() — so an existing
+    # install is picked up by the new API unchanged.
+    assert mm.DETECTOR_REGISTRY["desklib"]["repo"] == mm.MODEL_REPO
+    assert mm.detector_dir("desklib") == mm.model_path()
+
+
+def test_registry_per_arch_heads():
+    # Each Tier-1 detector declares the head the loader must use.
+    assert mm.DETECTOR_REGISTRY["desklib"]["head"] == "custom_mean_pool"
+    for k in ("superannotate", "e5-small-lora", "mage"):
+        assert mm.DETECTOR_REGISTRY[k]["head"] == "sequence_classification"
+
+
+def test_tier2_detectors_listed_but_not_installable():
+    # Honesty: heavy zero-shot/metric detectors are listed for transparency but
+    # are NOT installable and NEVER runnable (no fabricated support).
+    for key in ("binoculars", "fast-detectgpt", "radar"):
+        e = mm.DETECTOR_REGISTRY[key]
+        assert e["tier"] == 2
+        assert e["installable"] is False
+        assert e["heavy"] is True
+    assert "desklib" in mm.runnable_detector_keys()
+    assert "binoculars" not in mm.runnable_detector_keys()
+
+
+def test_registry_status_shape():
+    st = mm.registry_status()
+    assert st["default"] == "desklib"
+    assert isinstance(st["detectors"], list) and st["detectors"]
+    keys = {d["key"] for d in st["detectors"]}
+    assert {"desklib", "superannotate", "mage"} <= keys
+    for d in st["detectors"]:
+        for f in ("key", "repo", "arch", "head", "tier", "size_mb",
+                  "license", "installable", "installed", "state"):
+            assert f in d, f"detector status missing {f}"
+
+
+def test_unknown_detector_is_graceful():
+    assert mm.get_detector("does-not-exist") is None
+    st = mm.detector_status("does-not-exist")
+    assert st["installed"] is False and st["installable"] is False
+
+
+# ── Per-detector install / status / remove (mocked HF) ──────────────────────
+
+@pytest.fixture
+def detector_dir_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_MODEL_DIR", str(tmp_path))
+    # Deps are present so install isn't short-circuited by a missing runtime.
+    monkeypatch.setattr(mm, "deps_available", lambda: True)
+    return tmp_path
+
+
+def _install_via_mock(monkeypatch, key, *, weight_bytes=60 * 1024 * 1024):
+    """Drive a per-detector download with snapshot_download + HfApi mocked.
+
+    The fake snapshot_download writes config.json + a weight file into the
+    detector dir; the size metadata fetch reports a matching expected size.
+    """
+    dest = mm.detector_dir(key)
+
+    def fake_snapshot_download(repo_id, local_dir, **kw):
+        import os
+        os.makedirs(local_dir, exist_ok=True)
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+        with open(os.path.join(local_dir, "model.safetensors"), "wb") as f:
+            f.write(b"x" * weight_bytes)
+
+    fake_hub = type(sys)("huggingface_hub")
+    fake_hub.snapshot_download = fake_snapshot_download
+
+    class _Sib:
+        def __init__(self, size):
+            self.size = size
+
+    class _Info:
+        siblings = [_Sib(weight_bytes)]
+        sha = "deadbeef"
+
+    class _HfApi:
+        def model_info(self, repo, **kw):
+            return _Info()
+
+    fake_hub.HfApi = _HfApi
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+
+def test_install_status_remove_roundtrip_mocked(monkeypatch, detector_dir_env):
+    key = "superannotate"
+    _install_via_mock(monkeypatch, key)
+    assert mm.is_detector_installed(key) is False
+    res = mm.start_detector_download(key)
+    # Download runs on a background thread — wait for it.
+    t = mm._detector_threads.get(key)
+    if t:
+        t.join(timeout=20)
+    assert mm.is_detector_installed(key) is True
+    st = mm.detector_status(key)
+    assert st["installed"] is True
+    assert st["state"] == "installed"
+    assert st["size_bytes"] > 0
+    # Remove it.
+    mm.delete_detector(key)
+    assert mm.is_detector_installed(key) is False
+
+
+def test_install_refuses_tier2_without_download(monkeypatch, detector_dir_env):
+    res = mm.start_detector_download("binoculars")
+    assert res["installable"] is False
+    assert res["state"] in ("unavailable", "error")
+    assert mm.is_detector_installed("binoculars") is False
+
+
+def test_install_refuses_when_deps_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("REFCHECKER_AI_DETECTION_MODEL_DIR", str(tmp_path))
+    monkeypatch.setattr(mm, "deps_available", lambda: False)
+    res = mm.start_detector_download("mage")
+    assert res["state"] == "error"
+    assert res["error"] == "deps_not_installed"
+
+
+def test_desklib_install_delegates_to_legacy(monkeypatch, detector_dir_env):
+    # The default key must route through the legacy start_download/delete_model
+    # state machine, not the per-detector one.
+    called = {"start": 0, "delete": 0}
+    monkeypatch.setattr(mm, "start_download", lambda: called.__setitem__("start", called["start"] + 1))
+    monkeypatch.setattr(mm, "delete_model", lambda: called.__setitem__("delete", called["delete"] + 1))
+    monkeypatch.setattr(mm, "is_model_installed", lambda: False)
+    mm.start_detector_download("desklib")
+    mm.delete_detector("desklib")
+    assert called["start"] == 1 and called["delete"] == 1
+
+
+# ── Per-arch head selection (mocked engines) ───────────────────────────────
+
+class _FakeEngine:
+    """A deterministic stand-in for a loaded detector engine.
+
+    ``score`` returns a per-key constant so the multi-run aggregation + agreement
+    math is exercised without any real ML.
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    def score(self, text):
+        return self.value
+
+
+def test_load_selects_head_and_caches(monkeypatch, detector_dir_env):
+    from refchecker.ai_detection import local_backend
+    captured = {}
+
+    def fake_build(model_dir_path, head=None):
+        captured["dir"] = str(model_dir_path)
+        captured["head"] = head
+        return _FakeEngine(0.9)
+
+    monkeypatch.setattr(local_backend, "_build_engine_at", fake_build)
+    monkeypatch.setattr(mm, "is_detector_installed", lambda k: True)
+    local_backend._engines.clear()
+
+    eng = local_backend.load("superannotate")
+    assert isinstance(eng, _FakeEngine)
+    # The per-arch head from the registry was threaded to the builder.
+    assert captured["head"] == "sequence_classification"
+    assert captured["dir"] == str(mm.detector_dir("superannotate"))
+    # Cached on second load (builder not called again).
+    captured.clear()
+    eng2 = local_backend.load("superannotate")
+    assert eng2 is eng and "head" not in captured
+
+
+def test_load_rejects_uninstalled_and_tier2(monkeypatch, detector_dir_env):
+    from refchecker.ai_detection import local_backend
+    local_backend._engines.clear()
+    monkeypatch.setattr(mm, "is_detector_installed", lambda k: False)
+    with pytest.raises(FileNotFoundError):
+        local_backend.load("mage")
+    # Tier-2 / non-installable can never be loaded.
+    with pytest.raises(ValueError):
+        local_backend.load("binoculars")
+    with pytest.raises(ValueError):
+        local_backend.load("nope-not-real")
+
+
+# ── Multi-run aggregation + agreement math ─────────────────────────────────
+
+LONG_PROSE = (
+    "The cell membrane regulates the transport of molecules across its lipid "
+    "bilayer through a combination of passive diffusion and active transport "
+    "mechanisms that depend on embedded protein channels and carrier proteins. "
+    "Researchers have studied these processes for decades using a wide variety "
+    "of experimental and computational techniques in many laboratories. "
+) * 12
+
+
+def _patch_engines(monkeypatch, scores_by_key):
+    """Make local_backend.load return a fixed-score fake engine per key, and
+    mark every key installed + deps present."""
+    from refchecker.ai_detection import local_backend
+
+    def fake_load(key):
+        if key not in scores_by_key:
+            raise FileNotFoundError(key)
+        return _FakeEngine(scores_by_key[key])
+
+    monkeypatch.setattr(local_backend, "load", fake_load)
+    monkeypatch.setattr(mm, "is_detector_installed", lambda k: k in scores_by_key)
+    monkeypatch.setattr(mm, "deps_available", lambda: True)
+
+
+def test_run_detectors_per_detector_scores_and_bands(monkeypatch):
+    # desklib scores high (0.95), e5 scores low (0.05) → honest disagreement,
+    # NO synthetic ensemble truth.
+    _patch_engines(monkeypatch, {"desklib": 0.95, "e5-small-lora": 0.05})
+    out = multi_run.run_detectors(LONG_PROSE, ["desklib", "e5-small-lora"])
+    dets = {d["key"]: d for d in out["detectors"]}
+    assert dets["desklib"]["band"] == "high"
+    assert dets["desklib"]["overall_score"] == 0.95
+    assert dets["e5-small-lora"]["band"] == "low"
+    # No top-level fabricated "ensemble" score exists.
+    assert "overall_score" not in out
+    assert out["disclaimer"]
+
+
+def test_run_detectors_comparison_agreement_math(monkeypatch):
+    # Two detectors that AGREE (both high) → band_agreement True, pairwise 1.0.
+    _patch_engines(monkeypatch, {"desklib": 0.95, "mage": 0.97})
+    out = multi_run.run_detectors(LONG_PROSE, ["desklib", "mage"])
+    comp = out["comparison"]
+    assert set(comp["detectors_compared"]) == {"desklib", "mage"}
+    assert comp["band_agreement"] is True
+    assert comp["per_sentence"], "per-sentence agreement view must be populated"
+    for ps in comp["per_sentence"]:
+        assert ps["unanimous"] is True
+        assert ps["agreement_count"] == ps["detector_count"]
+    assert comp["pairwise_agreement"]
+    pa = comp["pairwise_agreement"][0]
+    assert pa["agreement"] == 1.0 and pa["shared_sentences"] > 0
+
+
+def test_run_detectors_records_disagreement(monkeypatch):
+    # One high, one low → band_agreement False, pairwise 0.0 (disagreement is
+    # signal, surfaced — not hidden behind an averaged number).
+    _patch_engines(monkeypatch, {"desklib": 0.95, "e5-small-lora": 0.02})
+    out = multi_run.run_detectors(LONG_PROSE, ["desklib", "e5-small-lora"])
+    comp = out["comparison"]
+    assert comp["band_agreement"] is False
+    pa = comp["pairwise_agreement"][0]
+    assert pa["agreement"] == 0.0
+
+
+def test_run_detectors_uninstalled_abstains_no_number(monkeypatch):
+    # desklib installed (high); superannotate NOT installed → it ABSTAINS with
+    # no score and is excluded from the agreement math.
+    _patch_engines(monkeypatch, {"desklib": 0.95})
+    out = multi_run.run_detectors(LONG_PROSE, ["desklib", "superannotate"])
+    dets = {d["key"]: d for d in out["detectors"]}
+    assert dets["superannotate"]["band"] == "unavailable"
+    assert dets["superannotate"]["overall_score"] is None
+    assert dets["superannotate"]["abstain_reason"] == "model_not_installed"
+    # Only the scored detector participates in comparison.
+    assert out["comparison"]["detectors_compared"] == ["desklib"]
+
+
+def test_run_detectors_tier2_key_abstains(monkeypatch):
+    _patch_engines(monkeypatch, {"desklib": 0.95})
+    out = multi_run.run_detectors(LONG_PROSE, ["desklib", "binoculars"])
+    dets = {d["key"]: d for d in out["detectors"]}
+    assert dets["binoculars"]["band"] == "unavailable"
+    assert dets["binoculars"]["overall_score"] is None
+    assert dets["binoculars"]["abstain_reason"] == "detector_not_runnable"
+
+
+def test_run_detectors_short_body_abstains_all(monkeypatch):
+    _patch_engines(monkeypatch, {"desklib": 0.95, "mage": 0.97})
+    out = multi_run.run_detectors("too short to assess", ["desklib", "mage"])
+    for d in out["detectors"]:
+        assert d["band"] in ("inconclusive", "unavailable")
+        assert d["overall_score"] is None
+    assert out["comparison"]["band_agreement"] is False
+
+
+def test_run_detectors_accepts_pages_list(monkeypatch):
+    _patch_engines(monkeypatch, {"desklib": 0.95})
+    pages = [LONG_PROSE[: len(LONG_PROSE) // 2], LONG_PROSE[len(LONG_PROSE) // 2:]]
+    out = multi_run.run_detectors(pages, ["desklib"])
+    assert out["detectors"][0]["key"] == "desklib"
+    assert out["word_count"] > 0
+
+
+def test_run_detectors_dedupes_and_defaults_keys(monkeypatch):
+    _patch_engines(monkeypatch, {"desklib": 0.5})
+    # Duplicate keys collapse; empty selection falls back to the default.
+    out = multi_run.run_detectors(LONG_PROSE, ["desklib", "desklib", ""])
+    assert [d["key"] for d in out["detectors"]] == ["desklib"]
+    out2 = multi_run.run_detectors(LONG_PROSE, [])
+    assert out2["detectors"][0]["key"] == "desklib"
+
+
+def test_per_detector_threshold_used_for_band(monkeypatch):
+    # A detector with a high own-threshold bands a mid score as medium, while a
+    # low-threshold detector would band the same score high. Prove the registry
+    # threshold (not a shared global) is what's applied.
+    from refchecker.ai_detection import multi_run as mr
+    assert mr._band_for_score(0.80, 0.85) == "medium"   # below its 0.85 high cut
+    assert mr._band_for_score(0.80, 0.70) == "high"     # above a 0.70 high cut
+    assert mr._band_for_score(0.10, 0.85) == "low"


### PR DESCRIPTION
A focused slice split out of umbrella PR #52, rebased clean on `main`. Builds on the existing `src/refchecker/ai_detection/` module.

**What:**
- Detector **registry** (`model_manager.py`) — install/run one or more open-source detectors (desklib/DeBERTa default + SuperAnnotate, e5-small-LoRA, MAGE; heavy zero-shot ones listed opt-in).
- `multi_run.py` — `run_detectors()` runs a chosen set side by side and reports per-sentence agreement + per-detector bands (no blended "ensemble" number).
- `runtime_manager.py`, `diagnostics.py`, `base.py` — model runtime/load hardening + honest abstain surfacing.

Honest by construction (uninstalled detector / too-short body → abstains, never fabricates a score). **72 tests passing.** The FastAPI passthrough of the detector selection is in the separate backend PR.

Part of splitting #52 into reviewable per-feature PRs.