### PR TITLE
CLI startup banner + CLI output polish

### DIFF
--- a/src/refchecker/__init__.py
+++ b/src/refchecker/__init__.py
@@ -4,7 +4,7 @@ RefChecker - Academic Paper Reference Validation Tool
 A comprehensive tool for validating reference accuracy in academic papers.
 """
 
-__version__ = "1.2.1"
+from .__version__ import __version__  # single source of truth (see __version__.py)
 __author__ = "RefChecker Team"
 __email__ = "markrussinovich@hotmail.com"
 

--- a/src/refchecker/core/refchecker.py
+++ b/src/refchecker/core/refchecker.py
@@ -28,7 +28,6 @@ Options:
 """
 
 import arxiv
-import pandas as pd
 import requests
 import re
 import datetime
@@ -3110,10 +3109,17 @@ class ArxivReferenceChecker:
             # v0.7.68: subtitle tolerance — "X: subtitle" vs "X" is the
             # same paper, not a Title mismatch. We landed here via DOI/ID
             # match so the records are confirmed-same.
-            from refchecker.utils.text_utils import titles_align_with_subtitle_tolerance
+            from refchecker.utils.text_utils import (
+                titles_align_with_subtitle_tolerance,
+                titles_match_with_typo_tolerance,
+            )
             _subtitle_ok = titles_align_with_subtitle_tolerance(title, paper_data.get('title'))
+            # We reached verify_db_reference via a DOI/ID match, so the records
+            # are confirmed-same paper. Tolerate small OCR/typo differences
+            # (e.g. an extra letter in the DB title) instead of flagging them.
+            _typo_ok = titles_match_with_typo_tolerance(title, paper_data.get('title'))
 
-            if normalized_title != db_title and not _subtitle_ok:
+            if normalized_title != db_title and not _subtitle_ok and not _typo_ok:
                 from refchecker.utils.error_utils import format_title_mismatch
                 # Clean the title for display (remove LaTeX commands like {LLM}s -> LLMs)
                 clean_cited_title = strip_latex_commands(title)
@@ -4467,7 +4473,21 @@ class ArxivReferenceChecker:
                     print(f"🚩 Total likely hallucinated: {flagged_count}")
                 if self.total_errors_found == 0 and self.total_warnings_found == 0 and self.total_info_found == 0 and total_unverified == 0:
                     print(f"✅ All references verified successfully!")
-                
+
+                # Citation-health grade — qualitative, derived only from the real
+                # aggregate verdicts (no fabricated precise %; the exact score is
+                # in the app/report).
+                if self.total_references_processed > 0:
+                    if flagged_count > 0:
+                        grade = "Critical — likely hallucinations present"
+                    elif self.total_errors_found > 0:
+                        grade = "Poor — errors need correction"
+                    elif self.total_warnings_found > 0 or total_unverified > 0:
+                        grade = "Fair — minor warnings / unverified"
+                    else:
+                        grade = "Excellent — all verified"
+                    print(f"🏅 Citation health: {grade}")
+
                 # Show warning if unreliable extraction was used and there are many errors
                 if self.used_unreliable_extraction and self.total_errors_found > 5:
                     print(f"\n⚠️  Results might be affected by incorrect reference extraction. Consider using LLM extraction, which is more robust.")
@@ -4496,7 +4516,19 @@ class ArxivReferenceChecker:
                 if flagged_count > 0:
                     print(f"🚩 Total likely hallucinated: {flagged_count}")
                     self._print_hallucination_console_summary(payload=structured_payload)
-                
+
+                # Citation-health grade for the batch (qualitative, real aggregates).
+                if self.total_references_processed > 0:
+                    if flagged_count > 0:
+                        grade = "Critical — likely hallucinations present"
+                    elif self.total_errors_found > 0:
+                        grade = "Poor — errors need correction"
+                    elif self.total_warnings_found > 0 or total_unverified > 0:
+                        grade = "Fair — minor warnings / unverified"
+                    else:
+                        grade = "Excellent — all verified"
+                    print(f"🏅 Citation health: {grade}")
+
                 # Show warning if unreliable extraction was used and there are many errors
                 if self.used_unreliable_extraction and self.total_errors_found > 5:
                     print(f"\n⚠️  Results might be affected by incorrect reference extraction. Consider using LLM extraction, which is more robust.")
@@ -7721,12 +7753,37 @@ def _update_local_databases(
 
 def main():
     """Main function to parse arguments and run the reference checker"""
-    print(f"Refchecker v{__version__} - Validate references in academic papers")
-    print(f"By Mark Russinovich and various agentic AI assistants")
+    # Hermes-Agent-style startup banner (ASCII logo + environment + capabilities).
+    # Printed to stderr so it never pollutes machine-readable stdout (e.g.
+    # --report-format json). Falls back to a one-liner if anything goes wrong.
+    try:
+        from refchecker.utils.banner import print_banner
+        print_banner(__version__)
+    except Exception:  # noqa: BLE001
+        print(f"Refchecker v{__version__} - Validate references in academic papers")
+        print("By Mark Russinovich and various agentic AI assistants")
 
     supported_openreview_help = 'Supported OpenReview shorthands: iclr, icml, aistats, uai, corl'
 
-    parser = argparse.ArgumentParser(description="Academic paper references checker")
+    parser = argparse.ArgumentParser(
+        prog="academic-refchecker",
+        description=(
+            "RefChecker — verify the references in an academic paper against "
+            "Semantic Scholar / OpenAlex / Crossref / DBLP / ACL / arXiv / "
+            "OpenReview, and optionally screen the manuscript for AI-generated text."
+        ),
+        epilog=(
+            "examples:\n"
+            "  academic-refchecker --paper 2406.01234\n"
+            "  academic-refchecker --paper https://arxiv.org/abs/2406.01234\n"
+            "  academic-refchecker --paper ./paper.pdf --report-format json\n"
+            "  academic-refchecker --paper ./refs.bib --output-file errors.txt\n"
+            "  academic-refchecker --paper-list papers.txt\n\n"
+            "AI-text detection is opt-in and ADVISORY ONLY — never proof of "
+            "misconduct. See the README for the full options and the desktop app."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--debug", action="store_true",
                         help="Run in debug mode with verbose logging")
     parser.add_argument("--paper", type=str,

--- a/src/refchecker/utils/banner.py
+++ b/src/refchecker/utils/banner.py
@@ -1,0 +1,201 @@
+"""Modern CLI banner for RefChecker.
+
+A block-pixel ``REFCHECKER`` wordmark with a cyan→green vertical gradient,
+followed by grouped, colour-coded command / environment / help panels — in the
+spirit of the Hermes / ChangeX CLI banners. Colour is truecolor ANSI,
+auto-disabled when stdout is not a TTY or ``NO_COLOR`` is set, so piped output
+stays clean.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import sys
+import shutil
+
+# ── Block-pixel font (5 rows tall, 6 cols wide per glyph) ──────────────────
+# BOLD 2-cell-wide strokes so each letter reads as one solid shape instead of a
+# scatter of thin blocks under the gradient — much more legible at a glance.
+_B = "█"
+_GLYPHS = {
+    "R": ["█████ ", "██  ██", "█████ ", "██ ██ ", "██  ██"],
+    "E": ["██████", "██    ", "█████ ", "██    ", "██████"],
+    "F": ["██████", "██    ", "█████ ", "██    ", "██    "],
+    "C": [" █████", "██    ", "██    ", "██    ", " █████"],
+    "H": ["██  ██", "██  ██", "██████", "██  ██", "██  ██"],
+    "K": ["██  ██", "██ ██ ", "████  ", "██ ██ ", "██  ██"],
+}
+_WORD = "REFCHECKER"
+
+# Plain (no-ANSI) wordmark for embedding in docs/README. One space between the
+# now-bold glyphs is enough separation while keeping the wordmark within an
+# 80-column terminal.
+PLAIN_LOGO = "\n".join(
+    " ".join(_GLYPHS[ch][row] for ch in _WORD) for row in range(5)
+)
+# Back-compat alias (older imports referenced LOGO).
+LOGO = "\n" + PLAIN_LOGO + "\n"
+
+# Vertical gradient stops cyan → aqua → green, one colour per wordmark row.
+_GRADIENT = [
+    (34, 211, 238),
+    (38, 211, 217),
+    (43, 211, 196),
+    (47, 211, 174),
+    (52, 211, 153),
+]
+
+
+def _supports_color(stream=None) -> bool:
+    # NO_COLOR always wins (https://no-color.org/).
+    if os.environ.get("NO_COLOR"):
+        return False
+    # FORCE_COLOR overrides TTY detection (CI, demos, recordings). Follow the
+    # Node convention where a falsey value (0/false/no/off) means *disable*.
+    fc = os.environ.get("FORCE_COLOR")
+    if fc is not None:
+        return fc.strip().lower() not in ("0", "false", "no", "off", "")
+    if os.environ.get("CLICOLOR_FORCE") == "1":
+        return True
+    # Probe the stream we ACTUALLY write to (stderr by default) — not stdout —
+    # so the banner stays colourised even when stdout is redirected/piped
+    # (e.g. `academic-refchecker --report-format json > out.json`), which is the
+    # common reason the banner used to render as plain white blocks.
+    s = stream if stream is not None else sys.stderr
+    try:
+        return bool(s.isatty())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+class _C:
+    def __init__(self, on: bool):
+        self.on = on
+
+    def _w(self, code: str, s: str) -> str:
+        return f"\033[{code}m{s}\033[0m" if self.on else s
+
+    def rgb(self, rgb, s: str) -> str:
+        if not self.on:
+            return s
+        r, g, b = rgb
+        return f"\033[38;2;{r};{g};{b}m{s}\033[0m"
+
+    def cyan(self, s):    return self.rgb((34, 211, 238), s)
+    def green(self, s):   return self.rgb((52, 211, 153), s)
+    def magenta(self, s): return self._w("1;38;2;217;108;255", s)
+    def yellow(self, s):  return self.rgb((250, 204, 21), s)
+    def dim(self, s):     return self._w("90", s)
+    def bold(self, s):    return self._w("1", s)
+    def white(self, s):   return self._w("97", s)
+
+
+def _ok(flag: bool, c: _C) -> str:
+    return c.green("●") if flag else c.dim("○")
+
+
+def _module_available(name: str) -> bool:
+    import importlib.util
+    try:
+        return importlib.util.find_spec(name) is not None
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _cmd(c: _C, name: str, desc: str, pad: int = 14) -> str:
+    """A 'command   description' row: cyan name, padded, dim-ish description."""
+    return f"    {c.cyan(name.ljust(pad))}{c.white(desc)}"
+
+
+def _section(c: _C, title: str, sub: str = "") -> str:
+    head = c.magenta(title)
+    if sub:
+        head += "  " + c.dim("· " + sub)
+    return "  " + head
+
+
+def render_banner(version: str, stream=None) -> str:
+    c = _C(_supports_color(stream if stream is not None else sys.stderr))
+    width = shutil.get_terminal_size((80, 24)).columns
+
+    # Capability probes (cheap — no heavy imports).
+    ai_runtime = _module_available("torch") or _module_available("onnxruntime")
+    transformers = _module_available("transformers")
+    llm_libs = _module_available("openai") or _module_available("anthropic") or _module_available("google")
+    py = platform.python_version()
+    osname = f"{platform.system()} {platform.release()}".strip()
+    arch = platform.machine()
+
+    lines = []
+
+    # ── Wordmark (block-pixel + gradient), or a compact title on narrow TTYs ──
+    # The full bold wordmark is ~69 cols wide; fall back to a compact title below.
+    if width >= 72:
+        for row in range(5):
+            line = " ".join(_GLYPHS[ch][row] for ch in _WORD)
+            lines.append("  " + c.rgb(_GRADIENT[row], line))
+    else:
+        lines.append("  " + c.bold(c.cyan("RefChecker")))
+    lines.append("")
+    lines.append(
+        f"  {c.dim('academic reference verification')}  {c.green('+')}  "
+        f"{c.dim('AI-text detection')}   {c.green('v' + str(version))}"
+    )
+    lines.append("")
+    lines.append(
+        f"  {c.bold(c.white('academic-refchecker'))} {c.dim('<input> [options]')}"
+        f"   {c.dim('·')}   {c.dim('add')} {c.cyan('--help')} {c.dim('for the full list')}"
+    )
+    lines.append("")
+
+    # ── Check ──
+    lines.append(_section(c, "Check"))
+    lines.append(_cmd(c, "--paper", "one paper — ArXiv ID, URL, PDF, .tex, .bib, or text"))
+    lines.append(_cmd(c, "--paper-list", "many papers from a newline-delimited file"))
+    lines.append(_cmd(c, "--openreview", "fetch + scan an entire OpenReview venue"))
+    lines.append("")
+
+    # ── AI-text detection ──
+    lines.append(_section(c, "AI-text detection", "opt-in, advisory — never proof of misconduct"))
+    lines.append(_cmd(c, "local", f"{_ok(ai_runtime and transformers, c)} desklib DeBERTa — offline & calibrated (download in Settings)"))
+    lines.append(_cmd(c, "llm-judge", "reuse your configured LLM provider (uncalibrated)"))
+    lines.append(_cmd(c, "external", "Pangram / GPTZero — key + explicit consent"))
+    lines.append("")
+
+    # ── Output ──
+    lines.append(_section(c, "Output"))
+    lines.append(_cmd(c, "--report-file", "structured report — json · jsonl · csv · text"))
+    lines.append(_cmd(c, "--output-file", "human-readable error list"))
+    lines.append("")
+
+    # ── Environment ──
+    lines.append(_section(c, "Environment"))
+    lines.append(
+        f"    {c.dim('python')} {c.white(py)}  {c.dim('·')}  {c.white(osname)} {c.dim('(' + arch + ')')}"
+    )
+    lines.append(
+        f"    {c.dim('runtime')}  {_ok(ai_runtime, c)} torch/onnx   "
+        f"{_ok(transformers, c)} transformers   {_ok(llm_libs, c)} llm sdks"
+    )
+    lines.append(
+        "    " + c.dim("sources  Semantic Scholar · OpenAlex · Crossref · DBLP · "
+                       "ACL Anthology · arXiv · OpenReview")
+    )
+    lines.append("")
+    if width >= 60:
+        lines.append("  " + c.dim("─" * min(width - 4, 72)))
+    return "\n".join(lines)
+
+
+def print_banner(version: str, stream=None) -> None:
+    """Print the banner to ``stream`` (stderr by default so it never pollutes
+    machine-readable stdout output like --report-format json)."""
+    out = stream if stream is not None else sys.stderr
+    try:
+        print(render_banner(version, out), file=out)
+    except Exception:  # noqa: BLE001
+        # Never let a cosmetic banner break the CLI.
+        try:
+            print(f"RefChecker v{version} - academic reference verification", file=out)
+        except Exception:  # noqa: BLE001
+            pass


### PR DESCRIPTION
A focused slice split out of umbrella PR #52, rebased clean on `main`.

**What:**
- `utils/banner.py` — a colourised ASCII startup banner (logo + environment + capabilities), printed to **stderr** so machine-readable stdout (`--report-format json`) stays clean; colour gated on `TTY` / `NO_COLOR` / `FORCE_COLOR`.
- `core/refchecker.py` — wires the banner into `main()`, adds a qualitative **citation-health grade** line to the run summary (derived only from real aggregate verdicts), and a typo-tolerant title-match guard in `verify_db_reference`.
- `__init__.py` — version made a single source of truth.

Note: the typo-title-match line uses `titles_match_with_typo_tolerance`, which ships in the companion PR **"Author, venue & accent matching improvements"** — merge that one first (or together). Compiles + banner imports clean.

Part of splitting #52 into reviewable per-feature PRs.