### PR TITLE
Fix four features that silently did nothing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,7 @@ from . import admin_insights
 from .database import db, get_data_dir, get_logs_dir
 from .websocket_manager import manager, presence
 from .refchecker_wrapper import ProgressRefChecker
+from .reference_status import classify_verification_result, split_errors_and_warnings
 from .models import CheckRequest, CheckHistoryItem
 from .concurrency import init_limiter, get_limiter, set_default_max_concurrent, DEFAULT_MAX_CONCURRENT
 from .cites_refs import fetch_cites_and_refs, normalize_mode as _normalize_overlap_mode
@@ -2958,15 +2959,23 @@ async def get_check_detail(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-async def _render_check_html(check_id: int, current_user: UserInfo) -> tuple[str, str]:
+async def _render_check_html(check_id: int, current_user: UserInfo, *,
+                             include: Optional[str] = None,
+                             corrections: bool = False,
+                             summary: Any = None) -> tuple[str, str]:
     """Resolve a check and render it to standalone HTML. Returns (title, html).
 
     Team-aware read (R26): a member of the team a check is shared with can export
     it, mirroring the shared-check detail view (renders only the already-shared
-    references + verdicts, no owner-only raw assets)."""
+    references + verdicts, no owner-only raw assets).
+
+    The report options are honoured here so a published link matches what the
+    share dialog was configured to produce, exactly as the download does."""
     check = await _get_accessible_check_or_404(check_id, current_user)
-    from backend.export import serialize_check_to_html
-    html_str = serialize_check_to_html(check)
+    from backend.export import serialize_check_to_html, parse_sections
+    html_str = serialize_check_to_html(
+        check, corrections=corrections,
+        sections=parse_sections(include), summary=summary)
     title = check.get("paper_title") or check.get("custom_label") or f"refchecker-{check_id}"
     return title, html_str
 
@@ -2994,6 +3003,12 @@ class _PublishRequest(BaseModel):
     adapter: str = "github_gist"   # 'github_gist'
     token: str = ""                 # caller-supplied PAT (gist scope)
     public: bool = False
+    # The share dialog's report options. Publishing used to ignore these and
+    # always emit the full default report, so unchecking a section (or asking
+    # for suggested corrections) silently had no effect on a published link.
+    include: Optional[str] = None
+    corrections: bool = False
+    summary: Optional[Dict[str, Any]] = None
 
 
 @app.get("/api/check/{check_id}/health")
@@ -3530,7 +3545,9 @@ async def publish_check(check_id: int, req: _PublishRequest,
     # per-adapter try/except — so any failure surfaced as a raw, detail-leaking
     # 500 for EVERY share type. Wrap it into a stable, generic 500.
     try:
-        title, html_str = await _render_check_html(check_id, current_user)
+        title, html_str = await _render_check_html(
+            check_id, current_user, include=req.include,
+            corrections=req.corrections, summary=req.summary)
     except HTTPException:
         raise
     except Exception as e:
@@ -3551,7 +3568,11 @@ async def publish_check(check_id: int, req: _PublishRequest,
                 raise HTTPException(status_code=404, detail="Check not found")
             from backend import export as _export
             try:
-                pdf_bytes = await asyncio.to_thread(_export.render_check_to_pdf, check)
+                pdf_bytes = await asyncio.to_thread(
+                    _export.render_check_to_pdf, check,
+                    corrections=req.corrections,
+                    sections=_export.parse_sections(req.include),
+                    summary=req.summary)
             except _export.PdfEngineUnavailableError as e:
                 # No PDF engine in this bundle: quick-link needs a PDF, so tell
                 # the user to use Publish-to-web or download HTML/MD instead.
@@ -7351,28 +7372,18 @@ async def verify_single_reference(
 
     # Assemble a verified result on top of the existing ref so the row
     # keeps its id/index but picks up the new status/errors/url.
-    sanitized = []
-    for err in (errors or []):
-        e_type = err.get('error_type') or err.get('warning_type') or err.get('info_type')
-        details = err.get('error_details') or err.get('warning_details') or err.get('info_details')
-        if not e_type and not details:
-            continue
-        sanitized.append({"error_type": e_type, "error_details": details})
-
-    has_error = any((s.get('error_type') and s.get('error_type') != 'unverified') for s in sanitized)
-    if verified_data and not has_error:
-        status = "verified"
-    elif verified_data:
-        status = "warning"
-    elif sanitized:
-        status = "unverified"
-    else:
-        status = "unverified"
+    # Use the same classifier as the batch path (backend/reference_status.py):
+    # this endpoint used to fold warning_type into error_type, which made
+    # status="error" unreachable (a real author mismatch was shown as a mild
+    # warning) while simultaneously putting warnings in `errors`, so the
+    # status icon contradicted the row's own status.
+    status, sanitized = classify_verification_result(dict(target), verified_data, errors, url)
+    ref_errors, ref_warnings = split_errors_and_warnings(sanitized)
 
     updated = dict(target)
     updated["status"] = status
-    updated["errors"] = [s for s in sanitized if s.get('error_type') and s.get('error_type') != 'unverified']
-    updated["warnings"] = []  # warnings come back through error_type for now
+    updated["errors"] = ref_errors
+    updated["warnings"] = ref_warnings
     updated["verified_url"] = url
     if verified_data:
         # Surface the canonical metadata in dedicated `verified_*` fields

--- a/backend/refchecker_wrapper.py
+++ b/backend/refchecker_wrapper.py
@@ -30,6 +30,7 @@ if _src_path not in sys.path and os.path.exists(_src_path):
 from backend.concurrency import create_limiter, get_default_max_concurrent
 from backend.auth import is_multiuser_mode
 from backend.database import get_data_dir
+from backend.reference_status import classify_verification_result, split_errors_and_warnings
 
 from refchecker.utils.text_utils import extract_latex_references
 from refchecker.utils.url_utils import extract_arxiv_id_from_url, construct_semantic_scholar_url
@@ -200,6 +201,39 @@ def _sentence_tokenize(text):
     return merged
 
 
+# Title comparison on the cached-verification path uses the SAME scorer and the
+# SAME acceptance threshold as every live checker, so a reference is judged by
+# one rule whether it was verified fresh or replayed from the cross-paper cache.
+# The primary cut-off is the shared config value, not a local constant.
+def _shared_title_similarity(a: str, b: str):
+    """Shared title similarity, or None if the scorer is unavailable."""
+    try:
+        from refchecker.utils.text_utils import calculate_title_similarity
+        return calculate_title_similarity((a or "").lower(), (b or "").lower())
+    except Exception:
+        logger.debug("shared title similarity unavailable", exc_info=True)
+        return None
+
+
+def _title_match_threshold() -> float:
+    try:
+        from refchecker.config.settings import get_config
+        return float(get_config()["text_processing"]["similarity_threshold"])
+    except Exception:
+        return 0.8
+
+
+# At or above this, the checkers consider the titles the same paper.
+_TITLE_MATCH_THRESHOLD = _title_match_threshold()
+# Well below the acceptance threshold the cache has most likely matched a
+# different work, which is an error rather than a wording discrepancy. Derived
+# from the shared threshold so there is still only one number to tune. Kept well
+# clear of the acceptance band deliberately: spelling variants of the same title
+# ("optimization"/"optimisation") score around 0.4 on the shared scorer, and
+# those are a discrepancy to flag, not grounds for calling it a different paper.
+_TITLE_MISMATCH_THRESHOLD = _TITLE_MATCH_THRESHOLD * 0.5
+
+
 def _diff_cited_vs_truth(reference, truth):
     """Compare a cited reference against a known-verified truth row.
 
@@ -269,13 +303,20 @@ def _diff_cited_vs_truth(reference, truth):
             return ""
         return _norm(parts[-1])
 
-    # ── Title (v0.7.55 per ML round 2) ────────────────────────────────
+    # ── Title ─────────────────────────────────────────────────────────
     # A fuzzy hit landed us here; if the fuzzy 60–80 char prefix match
     # had divergent suffix the cited paper might not actually be the
-    # cached paper. Compare normalized titles via token-set Jaccard:
-    #   >= 0.85  → silent (genuinely the same paper)
-    #   0.55..0.85 → warning
-    #   < 0.55  → error (likely mismatched cache record)
+    # cached paper.
+    #
+    # This MUST use the same similarity function and the same acceptance
+    # threshold as every live checker (crossref, semantic_scholar,
+    # local_semantic_scholar, openalex, arxiv). This path exists only in
+    # the WebUI — the CLI and bulk runners have no cross-paper cache — so
+    # a private formula here meant the same reference could be judged by
+    # different rules depending purely on whether it happened to be
+    # cached, which is exactly the divergence AGENTS.md forbids. The old
+    # raw token-Jaccard with hand-picked 0.55/0.85 cut-offs disagreed with
+    # the shared scorer across the whole middle of its range.
     def _title_tokens(s):
         s = (s or "").strip().lower()
         s = _re_dvt.sub(r"[^a-z0-9 ]+", " ", s)
@@ -292,30 +333,26 @@ def _diff_cited_vs_truth(reference, truth):
     except Exception:
         _subtitle_ok = False
     if cited_title and truth_title and not _subtitle_ok:
-        ct = _title_tokens(cited_title)
-        tt = _title_tokens(truth_title)
-        if ct and tt:
-            inter = len(ct & tt)
-            union = len(ct | tt)
-            jacc = inter / union if union else 0.0
-            if jacc < 0.55:
+        sim = _shared_title_similarity(cited_title, truth_title)
+        if sim is not None and sim < _TITLE_MATCH_THRESHOLD:
+            if sim < _TITLE_MISMATCH_THRESHOLD:
                 errors.append({
                     "error_type": "title",
                     "error_details": (
                         f"Cited title differs sharply from the cached "
-                        f"verification of this paper (Jaccard {jacc:.2f}). "
+                        f"verification of this paper (similarity {sim:.2f}). "
                         f"The cache may have matched a similarly-titled "
                         f"but distinct work."
                     ),
                     "cited_value": cited_title[:200],
                     "actual_value": truth_title[:200],
                 })
-            elif jacc < 0.85:
+            else:
                 warnings.append({
                     "warning_type": "title",
                     "warning_details": (
                         f"Cited title differs slightly from the cached "
-                        f"truth (Jaccard {jacc:.2f})."
+                        f"truth (similarity {sim:.2f})."
                     ),
                     "cited_value": cited_title[:200],
                     "actual_value": truth_title[:200],
@@ -1335,123 +1372,19 @@ class ProgressRefChecker:
         
         Shared by both async and sync verification methods.
         """
-        # Normalize errors to align with CLI behavior
+        # Normalize errors and derive the status via the canonical classifier
+        # in backend/reference_status.py, which the single-reference re-verify
+        # endpoint shares so both routes agree on severity.
         logger.info(f"_format_verification_result: raw errors={errors}")
-        sanitized = []
-        for err in (errors or []):
-            e_type = err.get('error_type') or err.get('warning_type') or err.get('info_type')
-            details = err.get('error_details') or err.get('warning_details') or err.get('info_details')
-            if not e_type and not details:
-                continue
-            # Track if this was originally an info_type (suggestion, not error)
-            is_info = 'info_type' in err
-            # Track if this was originally a warning_type (warning, not error)
-            is_warning = 'warning_type' in err
-            logger.info(f"Sanitizing error: e_type={e_type}, is_info={is_info}, is_warning={is_warning}, keys={list(err.keys())}")
-            # Backfill actual_value from the typed correction fields: "missing"
-            # issues (year/venue/title/authors) populate ONLY ref_*_correct, not
-            # actual_value, so the corrected-bibtex builder would otherwise drop
-            # exactly the value the warning told the user to add.
-            _actual = err.get('actual_value')
-            if not _actual:
-                _actual = (err.get('ref_year_correct') or err.get('ref_venue_correct')
-                           or err.get('ref_title_correct') or err.get('ref_authors_correct')
-                           or err.get('ref_doi_correct'))
-            _san = {
-                # Preserve original error_type for suggestion_type mapping;
-                # use is_suggestion flag for categorization instead.
-                # Map 'timeout' to 'unverified' since timeouts mean we couldn't verify
-                "error_type": 'unverified' if e_type == 'timeout' else (e_type or 'unknown'),
-                "error_details": details if e_type != 'timeout' else 'Verification timed out',
-                "cited_value": err.get('cited_value'),
-                "actual_value": _actual,
-                "is_suggestion": is_info,  # Preserve info_type as suggestion flag
-                "is_warning": is_warning,  # Preserve warning_type as warning flag
-            }
-            # Carry the typed correction fields through so the FE corrected-bibtex
-            # builder can recover year/venue/title/authors even when the checker
-            # only set the typed field (belt-and-suspenders with the backfill).
-            for _k in ("ref_year_correct", "ref_venue_correct", "ref_title_correct", "ref_authors_correct", "ref_doi_correct"):
-                if err.get(_k):
-                    _san[_k] = err.get(_k)
-            sanitized.append(_san)
-
-        # Determine status - items originally from warning_type are warnings, items from error_type are errors
-        # Items originally from info_type are suggestions, not errors
-        # Items originally from warning_type are warnings, not errors
-        # Items with error_type (including year/venue/author when missing) are errors
-        has_errors = any(
-            e.get('error_type') not in ['unverified'] 
-            and not e.get('is_suggestion')
-            and not e.get('is_warning')
-            # 'url' errors where the URL references the paper are informational,
-            # not real errors — the webpage checker confirmed the cited URL
-            # contains the paper title.
-            and not (
-                e.get('error_type') == 'url'
-                and 'url references paper' in (e.get('error_details') or '').lower()
-            )
-            for e in sanitized
+        status, sanitized = classify_verification_result(reference, verified_data, errors, url)
+        is_unverified = any(
+            (e.get('error_type') or e.get('warning_type')) in ('unverified', 'timeout')
+            for e in (errors or [])
         )
-        has_warnings = any(
-            e.get('is_warning')
-            and not e.get('is_suggestion') 
-            for e in sanitized
-        )
-        has_suggestions = any(e.get('is_suggestion') for e in sanitized)
-        is_unverified = any(e.get('error_type') == 'unverified' for e in sanitized)
-        # Check if the URL was confirmed to reference the paper (webpage checker verified it)
         url_references_paper = any(
             'url references paper' in (e.get('error_details') or '').lower()
             for e in (errors or [])
         )
-
-        if is_unverified:
-            from refchecker.checkers.web_search import is_academic_url
-
-            cited_url = reference.get('cited_url') or reference.get('url') or url or ''
-            real_errors = [
-                e for e in sanitized
-                if e.get('error_type') != 'unverified'
-                and not e.get('is_suggestion')
-                and not e.get('is_warning')
-            ]
-            cited_url_lower = cited_url.lower()
-            is_direct_pdf = cited_url_lower.split('?', 1)[0].endswith('.pdf')
-            if (
-                real_errors
-                and all(e.get('error_type') == 'url' for e in real_errors)
-                and not is_academic_url(cited_url)
-                and (not is_direct_pdf or 'openai.com' in cited_url_lower)
-            ):
-                sanitized = [e for e in sanitized if e.get('error_type') != 'url']
-                has_errors = False
-
-        if has_errors:
-            status = 'error'
-        elif has_warnings:
-            status = 'warning'
-        elif has_suggestions:
-            status = 'suggestion'
-        elif is_unverified and url_references_paper:
-            # The cited URL was checked and confirmed to contain the paper —
-            # treat as verified even though it wasn't found in academic databases.
-            status = 'verified'
-            # Strip the unverified + url-references-paper errors since they're
-            # now resolved — the URL confirms the paper exists.
-            sanitized = [
-                e for e in sanitized
-                if e.get('error_type') != 'unverified'
-                and not (
-                    e.get('error_type') == 'url'
-                    and 'url references paper' in (e.get('error_details') or '').lower()
-                )
-            ]
-        elif is_unverified:
-            status = 'unverified'
-        else:
-            status = 'verified'
-
         # Extract authoritative URLs with proper type detection
         authoritative_urls = []
         verified_via_cited_url = status == 'verified' and url_references_paper

--- a/backend/reference_status.py
+++ b/backend/reference_status.py
@@ -1,0 +1,169 @@
+"""Canonical verification-result classification for the web backend.
+
+Turning the checker's raw `(verified_data, errors, url)` tuple into a status and
+a sanitized issue list is subtle: the checker signals severity by *which key* it
+sets (`error_type` / `warning_type` / `info_type`), and several categories get
+reclassified after the fact (timeouts become "unverified", a URL error against a
+non-academic link is dropped when the webpage checker already confirmed the
+paper, and so on).
+
+This lived inline in `ProgressRefChecker._format_verification_result`, which
+meant the single-reference re-verify endpoint in `main.py` had its own
+hand-rolled copy. That copy flattened `warning_type` into `error_type` and so
+could never return `error` — re-verifying a reference with a genuine author
+mismatch silently downgraded it to a warning, while the very same checker output
+came back as an error through the normal batch flow.
+
+Both callers now share the implementation below.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def sanitize_errors(errors: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    """Normalize raw checker findings, preserving their original severity.
+
+    The checker distinguishes severity by key (`error_type` vs `warning_type` vs
+    `info_type`); collapsing them all onto `error_type` without recording where
+    they came from is what made severity unrecoverable downstream, so the origin
+    is kept as the `is_warning` / `is_suggestion` flags.
+    """
+    sanitized: List[Dict[str, Any]] = []
+    for err in (errors or []):
+        e_type = err.get('error_type') or err.get('warning_type') or err.get('info_type')
+        details = err.get('error_details') or err.get('warning_details') or err.get('info_details')
+        if not e_type and not details:
+            continue
+        is_info = 'info_type' in err
+        is_warning = 'warning_type' in err
+        # Backfill actual_value from the typed correction fields: "missing"
+        # issues (year/venue/title/authors) populate ONLY ref_*_correct, not
+        # actual_value, so the corrected-bibtex builder would otherwise drop
+        # exactly the value the warning told the user to add.
+        _actual = err.get('actual_value')
+        if not _actual:
+            _actual = (err.get('ref_year_correct') or err.get('ref_venue_correct')
+                       or err.get('ref_title_correct') or err.get('ref_authors_correct')
+                       or err.get('ref_doi_correct'))
+        _san = {
+            # Map 'timeout' to 'unverified' since timeouts mean we couldn't verify.
+            "error_type": 'unverified' if e_type == 'timeout' else (e_type or 'unknown'),
+            "error_details": details if e_type != 'timeout' else 'Verification timed out',
+            "cited_value": err.get('cited_value'),
+            "actual_value": _actual,
+            "is_suggestion": is_info,
+            "is_warning": is_warning,
+        }
+        # Carry the typed correction fields through so the FE corrected-bibtex
+        # builder can recover year/venue/title/authors even when the checker
+        # only set the typed field.
+        for _k in ("ref_year_correct", "ref_venue_correct", "ref_title_correct",
+                   "ref_authors_correct", "ref_doi_correct"):
+            if err.get(_k):
+                _san[_k] = err.get(_k)
+        sanitized.append(_san)
+    return sanitized
+
+
+def _is_url_references_paper(entry: Dict[str, Any]) -> bool:
+    """A 'url' finding the webpage checker resolved in the reference's favour."""
+    return (
+        entry.get('error_type') == 'url'
+        and 'url references paper' in (entry.get('error_details') or '').lower()
+    )
+
+
+def classify_verification_result(
+    reference: Dict[str, Any],
+    verified_data: Optional[Dict[str, Any]],
+    errors: Optional[List[Dict[str, Any]]],
+    url: Optional[str],
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Return `(status, sanitized_errors)` for one verified reference.
+
+    `status` is one of: error, warning, suggestion, verified, unverified.
+    """
+    sanitized = sanitize_errors(errors)
+
+    has_errors = any(
+        e.get('error_type') not in ['unverified']
+        and not e.get('is_suggestion')
+        and not e.get('is_warning')
+        # 'url' errors where the URL references the paper are informational,
+        # not real errors — the webpage checker confirmed the cited URL
+        # contains the paper title.
+        and not _is_url_references_paper(e)
+        for e in sanitized
+    )
+    has_warnings = any(e.get('is_warning') and not e.get('is_suggestion') for e in sanitized)
+    has_suggestions = any(e.get('is_suggestion') for e in sanitized)
+    is_unverified = any(e.get('error_type') == 'unverified' for e in sanitized)
+    url_references_paper = any(
+        'url references paper' in (e.get('error_details') or '').lower()
+        for e in (errors or [])
+    )
+
+    if is_unverified:
+        from refchecker.checkers.web_search import is_academic_url
+
+        cited_url = reference.get('cited_url') or reference.get('url') or url or ''
+        real_errors = [
+            e for e in sanitized
+            if e.get('error_type') != 'unverified'
+            and not e.get('is_suggestion')
+            and not e.get('is_warning')
+        ]
+        cited_url_lower = cited_url.lower()
+        is_direct_pdf = cited_url_lower.split('?', 1)[0].endswith('.pdf')
+        if (
+            real_errors
+            and all(e.get('error_type') == 'url' for e in real_errors)
+            and not is_academic_url(cited_url)
+            and (not is_direct_pdf or 'openai.com' in cited_url_lower)
+        ):
+            sanitized = [e for e in sanitized if e.get('error_type') != 'url']
+            has_errors = False
+
+    if has_errors:
+        status = 'error'
+    elif has_warnings:
+        status = 'warning'
+    elif has_suggestions:
+        status = 'suggestion'
+    elif is_unverified and url_references_paper:
+        # The cited URL was checked and confirmed to contain the paper —
+        # treat as verified even though it wasn't found in academic databases.
+        status = 'verified'
+        # Strip the unverified + url-references-paper errors since they're
+        # now resolved — the URL confirms the paper exists.
+        sanitized = [
+            e for e in sanitized
+            if e.get('error_type') != 'unverified' and not _is_url_references_paper(e)
+        ]
+    elif is_unverified:
+        status = 'unverified'
+    else:
+        status = 'verified'
+
+    return status, sanitized
+
+
+def split_errors_and_warnings(
+    sanitized: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Split a sanitized list into the `errors` / `warnings` fields of a row.
+
+    Keeping warnings out of `errors` matters for display as well as counts: the
+    status-icon precedence is hallucination > error > warning, so a warning left
+    sitting in `errors` renders an error icon that contradicts the row's own
+    status.
+    """
+    errors = [
+        e for e in sanitized
+        if e.get('error_type')
+        and e.get('error_type') != 'unverified'
+        and not e.get('is_warning')
+        and not e.get('is_suggestion')
+    ]
+    warnings = [e for e in sanitized if e.get('is_warning') and not e.get('is_suggestion')]
+    return errors, warnings

--- a/src/refchecker/checkers/crossref.py
+++ b/src/refchecker/checkers/crossref.py
@@ -38,6 +38,31 @@ from refchecker.config.settings import get_config
 # Set up logging
 logger = logging.getLogger(__name__)
 
+
+def _normalize_crossref_work(work: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Flatten CrossRef's list-valued metadata fields to plain strings.
+
+    CrossRef returns `"title": ["Attention Is All You Need"]` — a list, even for
+    a single title — and does the same for `container-title`, `short-container-title`
+    and `subtitle`. The title-search paths already unwrap this before matching,
+    but the DOI lookup returned the raw message, so a DOI-verified reference
+    carried a *list* in `title`. That value is copied straight into the
+    "corrected reference" the user sees, which rendered as
+    `['Attention Is All You Need']`, and any consumer calling `.strip()` on it
+    raises `AttributeError`.
+
+    Normalizing here keeps the returned shape identical no matter which lookup
+    path found the work.
+    """
+    if not work:
+        return work
+    normalized = dict(work)
+    for key in ('title', 'container-title', 'short-container-title', 'subtitle'):
+        value = normalized.get(key)
+        if isinstance(value, list):
+            normalized[key] = str(value[0]) if value else ''
+    return normalized
+
 # Get configuration
 config = get_config()
 SIMILARITY_THRESHOLD = config["text_processing"]["similarity_threshold"]
@@ -236,10 +261,10 @@ class CrossRefReferenceChecker:
         from refchecker.utils.cache_utils import cached_api_response, cache_api_response
         hit = cached_api_response(getattr(self, 'cache_dir', None), 'crossref', 'get_by_doi', doi)
         if hit is not None:
-            return hit
+            return _normalize_crossref_work(hit)
         result = self._get_work_by_doi_uncached(doi)
         cache_api_response(getattr(self, 'cache_dir', None), 'crossref', 'get_by_doi', doi, result)
-        return result
+        return _normalize_crossref_work(result)
 
     def _get_work_by_doi_uncached(self, doi: str) -> Optional[Dict[str, Any]]:
         # Clean DOI - remove any prefixes

--- a/src/refchecker/core/verification_logic_version.py
+++ b/src/refchecker/core/verification_logic_version.py
@@ -27,8 +27,12 @@ History:
     3 - post-parse field fixups now run on the WebUI path too. They were only
         ever applied by the CLI/bulk wrapper, so WebUI verdicts were produced
         against uncorrected venue/title/author fields.
+    4 - the cached-verification (fuzzy Seen-Refs hit) path now compares titles
+        with the shared scorer and the shared acceptance threshold instead of a
+        private token-Jaccard with its own cut-offs, so a reference is judged
+        the same whether it was verified fresh or replayed from cache.
 """
 
-VERIFICATION_LOGIC_VERSION = 3
+VERIFICATION_LOGIC_VERSION = 4
 
 __all__ = ["VERIFICATION_LOGIC_VERSION"]

--- a/tests/unit/test_cached_title_comparison_parity.py
+++ b/tests/unit/test_cached_title_comparison_parity.py
@@ -1,0 +1,126 @@
+"""The cached-verification path must judge titles by the shared rules.
+
+`_diff_cited_vs_truth` runs when the WebUI gets a fuzzy hit in the cross-paper
+"Seen References" cache. That cache exists only in the WebUI — the CLI and bulk
+runners have no equivalent — so any private comparison logic here means the same
+reference is judged by different rules depending purely on whether it happened
+to be cached already.
+
+It used to compute a raw token-set Jaccard (no stop-word filtering, no phrase
+weighting) and compare it against hand-picked 0.55 / 0.85 cut-offs, entirely
+independent of `calculate_title_similarity` and the shared
+`similarity_threshold` that every live checker uses. The two disagreed across
+the middle of the range, so a reference could come back verified when checked
+fresh and warned when replayed from cache.
+"""
+
+import pytest
+
+from backend.refchecker_wrapper import (
+    _TITLE_MATCH_THRESHOLD,
+    _TITLE_MISMATCH_THRESHOLD,
+    _diff_cited_vs_truth,
+)
+from refchecker.config.settings import get_config
+from refchecker.utils.text_utils import calculate_title_similarity
+
+
+def _title_verdict(cited_title, truth_title):
+    """'error' | 'warning' | 'clean' for the title comparison alone."""
+    errors, warnings = _diff_cited_vs_truth(
+        {'title': cited_title, 'year': 2020, 'authors': 'A. Author'},
+        {'title': truth_title, 'year': 2020, 'authors': 'A. Author'},
+    )
+    if any(e.get('error_type') == 'title' for e in errors):
+        return 'error'
+    if any(w.get('warning_type') == 'title' for w in warnings):
+        return 'warning'
+    return 'clean'
+
+
+class TestThresholdsComeFromSharedConfig:
+    def test_acceptance_threshold_is_the_shared_one(self):
+        expected = float(get_config()['text_processing']['similarity_threshold'])
+        assert _TITLE_MATCH_THRESHOLD == expected
+
+    def test_mismatch_tier_sits_below_acceptance(self):
+        assert 0 < _TITLE_MISMATCH_THRESHOLD < _TITLE_MATCH_THRESHOLD
+
+
+class TestAgreesWithTheSharedScorer:
+    """A title the checkers would accept must not be flagged from cache."""
+
+    SAME_PAPER = [
+        ('A Survey of Large Language Models', 'A Survey on Large Language Models'),
+        ('Language Models are Few-Shot Learners', 'Language models are few shot learners'),
+        ('ImageNet Classification with Deep Convolutional Neural Networks',
+         'ImageNet classification with deep convolutional neural networks'),
+        ('Attention Is All You Need', 'Attention Is All You Need'),
+    ]
+
+    DIFFERENT_PAPER = [
+        ('Attention Is All You Need', 'Deep Residual Learning for Image Recognition'),
+        ('Learning to Summarize from Human Feedback',
+         'A Survey of Quantum Error Correction Codes'),
+    ]
+
+    @pytest.mark.parametrize('cited,truth', SAME_PAPER)
+    def test_titles_the_checkers_accept_are_not_flagged(self, cited, truth):
+        assert calculate_title_similarity(cited.lower(), truth.lower()) >= _TITLE_MATCH_THRESHOLD
+        assert _title_verdict(cited, truth) == 'clean'
+
+    @pytest.mark.parametrize('cited,truth', DIFFERENT_PAPER)
+    def test_clearly_different_works_are_errors(self, cited, truth):
+        assert _title_verdict(cited, truth) == 'error'
+
+    @pytest.mark.parametrize('cited,truth', SAME_PAPER + DIFFERENT_PAPER)
+    def test_clean_boundary_never_diverges_from_the_shared_scorer(self, cited, truth):
+        """The single most important property: the 'is this the same paper?'
+        answer must be identical on the cached path and the live path."""
+        shared_says_same = (
+            calculate_title_similarity(cited.lower(), truth.lower()) >= _TITLE_MATCH_THRESHOLD
+        )
+        cache_says_same = _title_verdict(cited, truth) == 'clean'
+        assert cache_says_same == shared_says_same
+
+
+class TestSeverityIsProportionate:
+    def test_spelling_variant_warns_rather_than_erroring(self):
+        """A discrepancy to flag, not grounds for 'this is a different paper'."""
+        verdict = _title_verdict('Adam: A Method for Stochastic Optimization',
+                                 'Adam: A method for stochastic optimisation')
+        assert verdict == 'warning'
+
+    def test_subtitle_difference_is_not_flagged(self):
+        """A paper cited with its subtitle against a record without one.
+
+        The shared helper deliberately requires a substantial (>=20 char) head
+        before accepting a subtitle-only difference, so that a short title like
+        "Deep Learning" cannot swallow every paper starting with those words.
+        """
+        assert _title_verdict(
+            'A Torn Discoid Lateral Meniscus Impacts Lower-Limb Alignment '
+            'Regardless of Age: surgical treatment may not be appropriate',
+            'A Torn Discoid Lateral Meniscus Impacts Lower-Limb Alignment '
+            'Regardless of Age') == 'clean'
+
+    def test_short_titled_subtitle_difference_only_warns(self):
+        """Below the helper's head-length floor there is not enough evidence to
+        call it the same paper — but it must not be escalated to an error."""
+        assert _title_verdict(
+            'The Menlo Report: Ethical Principles Guiding Information and '
+            'Communication Technology Research',
+            'The Menlo Report') == 'warning'
+
+    def test_missing_titles_are_not_flagged(self):
+        assert _title_verdict('', 'Some Cached Title') == 'clean'
+        assert _title_verdict('Some Cited Title', '') == 'clean'
+
+
+def test_no_private_jaccard_remains():
+    """Guard against the private formula creeping back in."""
+    import inspect
+
+    source = inspect.getsource(_diff_cited_vs_truth)
+    assert '_shared_title_similarity' in source
+    assert 'jacc' not in source, 'title comparison must use the shared scorer'

--- a/tests/unit/test_crossref_doi_shape.py
+++ b/tests/unit/test_crossref_doi_shape.py
@@ -1,0 +1,96 @@
+"""CrossRef must return the same metadata shape from every lookup path.
+
+CrossRef's API wraps several fields in lists even when there is only one value:
+`"title": ["Attention Is All You Need"]`. The title-search and bibliographic-search
+paths unwrapped this before matching, but the DOI lookup returned the raw
+`message`, so a DOI-verified reference carried a list in `title`.
+
+That value is copied into the "corrected reference" shown to the user, where it
+rendered literally as `['Attention Is All You Need']`, and any consumer calling
+a string method on it raises `AttributeError`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from refchecker.checkers.crossref import CrossRefReferenceChecker, _normalize_crossref_work
+
+# A realistic CrossRef `message` payload, with the list-valued fields intact.
+RAW_MESSAGE = {
+    'DOI': '10.1109/5.771073',
+    'title': ['Toward unique identifiers'],
+    'container-title': ['Proceedings of the IEEE'],
+    'short-container-title': ['Proc. IEEE'],
+    'subtitle': [],
+    'author': [{'given': 'N.', 'family': 'Paskin'}],
+    'issued': {'date-parts': [[1999, 7]]},
+    'URL': 'http://dx.doi.org/10.1109/5.771073',
+}
+
+
+class TestNormalizer:
+    def test_single_element_lists_become_strings(self):
+        out = _normalize_crossref_work(RAW_MESSAGE)
+        assert out['title'] == 'Toward unique identifiers'
+        assert out['container-title'] == 'Proceedings of the IEEE'
+        assert out['short-container-title'] == 'Proc. IEEE'
+
+    def test_empty_lists_become_empty_strings(self):
+        assert _normalize_crossref_work(RAW_MESSAGE)['subtitle'] == ''
+
+    def test_non_list_values_are_untouched(self):
+        out = _normalize_crossref_work({'title': 'Already A String', 'DOI': '10.1/x'})
+        assert out['title'] == 'Already A String'
+        assert out['DOI'] == '10.1/x'
+
+    def test_unrelated_fields_survive(self):
+        out = _normalize_crossref_work(RAW_MESSAGE)
+        assert out['author'] == RAW_MESSAGE['author']
+        assert out['URL'] == RAW_MESSAGE['URL']
+
+    def test_input_is_not_mutated(self):
+        payload = {'title': ['A Title']}
+        _normalize_crossref_work(payload)
+        assert payload['title'] == ['A Title']
+
+    @pytest.mark.parametrize('falsy', [None, {}])
+    def test_missing_work_passes_through(self, falsy):
+        assert _normalize_crossref_work(falsy) == falsy
+
+
+class TestDoiLookupShape:
+    def _checker(self):
+        c = CrossRefReferenceChecker()
+        c.cache_dir = None
+        return c
+
+    def test_doi_path_returns_a_string_title(self):
+        checker = self._checker()
+        with patch.object(checker, '_get_work_by_doi_uncached', return_value=dict(RAW_MESSAGE)):
+            work = checker.get_work_by_doi('10.1109/5.771073')
+        assert isinstance(work['title'], str)
+        assert work['title'].strip() == 'Toward unique identifiers'
+
+    def test_a_cached_raw_response_is_normalized_too(self):
+        """Entries written to the API cache before this fix still hold lists."""
+        checker = self._checker()
+        with patch('refchecker.utils.cache_utils.cached_api_response',
+                   return_value=dict(RAW_MESSAGE)):
+            work = checker.get_work_by_doi('10.1109/5.771073')
+        assert isinstance(work['title'], str)
+
+    def test_verified_title_can_be_used_as_a_correction(self):
+        """The exact downstream use: copying the canonical title into the
+        corrected reference shown to the user."""
+        checker = self._checker()
+        with patch.object(checker, '_get_work_by_doi_uncached', return_value=dict(RAW_MESSAGE)):
+            verified, _errors, _url = checker.verify_reference({
+                'title': 'Toward unique identifiers',
+                'authors': [],
+                'year': 1999,
+                'doi': '10.1109/5.771073',
+            })
+        corrected = {'title': verified['title']}
+        assert corrected['title'] == 'Toward unique identifiers'
+        assert '[' not in str(corrected['title'])

--- a/tests/unit/test_reverify_status_parity.py
+++ b/tests/unit/test_reverify_status_parity.py
@@ -1,0 +1,115 @@
+"""Single-reference re-verify must classify results like the batch path.
+
+`POST /api/history/{check_id}/references/{ref_id}/verify` used to sanitize the
+checker's findings with its own inline logic that folded `warning_type` into
+`error_type`. Two things went wrong as a result:
+
+  * `status = "error"` was unreachable — the branch only chose between
+    "verified" and "warning" — so re-verifying a reference with a genuine author
+    or DOI mismatch downgraded it to a mild warning, while the identical checker
+    output shown through the normal batch flow was correctly an error.
+  * every finding was written to `errors` and `warnings` was hard-coded to `[]`,
+    so a warning-only reference rendered the *error* icon (precedence is
+    hallucination > error > warning) while its own status said "warning".
+
+Both routes now share `backend.reference_status`.
+"""
+
+import pytest
+
+from backend.reference_status import (
+    classify_verification_result,
+    sanitize_errors,
+    split_errors_and_warnings,
+)
+
+REF = {'title': 'Attention Is All You Need', 'authors': 'A. Author', 'year': 2017}
+VERIFIED = {'title': 'Attention Is All You Need'}
+
+
+def _classify(errors, verified_data=VERIFIED, reference=REF, url=None):
+    status, sanitized = classify_verification_result(reference, verified_data, errors, url)
+    errs, warns = split_errors_and_warnings(sanitized)
+    return status, errs, warns
+
+
+class TestSeverityIsPreserved:
+    def test_genuine_error_is_an_error(self):
+        status, errs, warns = _classify(
+            [{'error_type': 'author', 'error_details': 'Cited authors do not match'}])
+        assert status == 'error'
+        assert len(errs) == 1 and warns == []
+
+    def test_warning_stays_a_warning(self):
+        status, errs, warns = _classify(
+            [{'warning_type': 'venue', 'warning_details': 'Venue differs'}])
+        assert status == 'warning'
+        assert errs == [], 'a warning in `errors` renders the wrong status icon'
+        assert len(warns) == 1
+
+    def test_suggestion_is_neither_error_nor_warning(self):
+        status, errs, warns = _classify(
+            [{'info_type': 'doi', 'info_details': 'Consider adding a DOI'}])
+        assert status == 'suggestion'
+        assert errs == [] and warns == []
+
+    def test_error_outranks_warning(self):
+        status, errs, warns = _classify([
+            {'error_type': 'year', 'error_details': 'Year mismatch'},
+            {'warning_type': 'venue', 'warning_details': 'Venue differs'},
+        ])
+        assert status == 'error'
+        assert len(errs) == 1 and len(warns) == 1
+
+    def test_no_findings_is_verified(self):
+        assert _classify([])[0] == 'verified'
+
+    def test_unmatched_reference_is_unverified(self):
+        status, _, _ = _classify(
+            [{'error_type': 'unverified', 'error_details': 'Not found in any database'}],
+            verified_data=None)
+        assert status == 'unverified'
+
+
+class TestSanitizeErrors:
+    def test_origin_of_each_finding_is_recorded(self):
+        out = sanitize_errors([
+            {'error_type': 'author', 'error_details': 'x'},
+            {'warning_type': 'venue', 'warning_details': 'y'},
+            {'info_type': 'doi', 'info_details': 'z'},
+        ])
+        assert [(e['is_warning'], e['is_suggestion']) for e in out] == [
+            (False, False), (True, False), (False, True)]
+
+    def test_timeouts_are_reported_as_unverified(self):
+        out = sanitize_errors([{'error_type': 'timeout', 'error_details': 'took too long'}])
+        assert out[0]['error_type'] == 'unverified'
+        assert out[0]['error_details'] == 'Verification timed out'
+
+    def test_empty_findings_are_dropped(self):
+        assert sanitize_errors([{}, {'error_type': None, 'error_details': None}]) == []
+
+    @pytest.mark.parametrize('field,value', [
+        ('ref_year_correct', 2018),
+        ('ref_venue_correct', 'NeurIPS'),
+        ('ref_title_correct', 'The Real Title'),
+        ('ref_authors_correct', 'Real Author'),
+        ('ref_doi_correct', '10.1000/xyz'),
+    ])
+    def test_typed_corrections_backfill_actual_value(self, field, value):
+        """The corrected-bibtex builder reads actual_value; "missing X" findings
+        only populate the typed field, so it has to be backfilled."""
+        out = sanitize_errors([{'warning_type': 'venue', 'warning_details': 'missing', field: value}])
+        assert out[0]['actual_value'] == value
+        assert out[0][field] == value
+
+
+def test_reverify_endpoint_uses_the_shared_classifier():
+    """Guard against the endpoint growing a private copy again."""
+    import inspect
+
+    from backend import main
+
+    source = inspect.getsource(main.verify_single_reference)
+    assert 'classify_verification_result' in source
+    assert 'warnings come back through error_type' not in source

--- a/web-ui/src/components/Modals/ShareModal.jsx
+++ b/web-ui/src/components/Modals/ShareModal.jsx
@@ -145,11 +145,20 @@ export default function ShareModal({ checkId, batchId, title, onClose }) {
 
   const [shareNote, setShareNote] = useState('')
 
+  // The publish paths take the SAME report options as the download, so a
+  // published link matches what the dialog was configured to produce. Without
+  // this, unchecking a section had no effect on a shared link.
+  const reportOpts = () => ({
+    include: includeList.length ? includeList.join(',') : undefined,
+    corrections,
+    summary: summary.canonical,
+  })
+
   const handlePublish = async () => {
     setBusy('publish'); setError(''); setShareUrl(''); setShareNote('')
     try {
       localStorage.setItem('refchecker.githubToken', token)
-      const res = await publishCheck(checkId, { adapter: 'github_gist', token, public: isPublic })
+      const res = await publishCheck(checkId, { adapter: 'github_gist', token, public: isPublic, ...reportOpts() })
       setShareUrl(res.data?.url || '')
     } catch (e) {
       setError(e?.response?.data?.detail || e?.message || 'Publish failed')
@@ -160,7 +169,7 @@ export default function ShareModal({ checkId, batchId, title, onClose }) {
   const handleQuickLink = async () => {
     setBusy('quicklink'); setError(''); setShareUrl(''); setShareNote('')
     try {
-      const res = await publishCheck(checkId, { adapter: 'quick_link' })
+      const res = await publishCheck(checkId, { adapter: 'quick_link', ...reportOpts() })
       setShareUrl(res.data?.url || '')
       setShareNote('Anonymous PDF report link — no account or domain needed. Public to anyone with the URL and expires after a while.')
     } catch (e) {

--- a/web-ui/src/components/Modals/ShareModal.publish.test.jsx
+++ b/web-ui/src/components/Modals/ShareModal.publish.test.jsx
@@ -1,0 +1,122 @@
+import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The share dialog's report options (which sections to include, and whether to
+// add suggested corrections) were only ever applied to the DOWNLOAD. Both
+// publish paths — "Publish to web" and "Quick link" — called publishCheck with
+// nothing but the adapter/token, so the server re-rendered the full default
+// report. A user who unchecked "AI-text detection" and published a link still
+// published the AI section. Nothing reported the discrepancy.
+
+vi.mock('./ShareAnimationCanvas', () => ({
+  default: () => <div data-testid="share-video" />,
+}))
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const publishCheck = vi.fn(() => Promise.resolve({ data: { url: 'https://example.com/r' } }))
+const exportCheckFile = vi.fn(() => Promise.resolve({ data: new Blob(['x']) }))
+vi.mock('../../utils/api', () => ({
+  exportCheckFile: (...a) => exportCheckFile(...a),
+  exportBatchFile: vi.fn(),
+  publishCheck: (...a) => publishCheck(...a),
+}))
+
+const checkState = { references: [], aiDetection: null, stats: {} }
+vi.mock('../../stores/useCheckStore', () => {
+  const useCheckStore = (selector) => (selector ? selector(checkState) : checkState)
+  useCheckStore.getState = () => checkState
+  return { useCheckStore }
+})
+
+let historyState = { selectedCheck: null }
+vi.mock('../../stores/useHistoryStore', () => {
+  const useHistoryStore = (selector) => (selector ? selector(historyState) : historyState)
+  useHistoryStore.getState = () => historyState
+  return { useHistoryStore }
+})
+
+let styleState = { format: 'ieee' }
+vi.mock('../../stores/useStyleStore', () => {
+  const useStyleStore = (selector) => (selector ? selector(styleState) : styleState)
+  useStyleStore.getState = () => styleState
+  return { useStyleStore }
+})
+
+import ShareModal from './ShareModal'
+
+const references = [
+  { status: 'verified', errors: [], warnings: [] },
+  { status: 'error', errors: [{ error_type: 'author', message: 'author mismatch' }], warnings: [] },
+]
+
+beforeEach(() => {
+  historyState = {
+    selectedCheck: {
+      status: 'completed',
+      references,
+      ai_detection: { band: 'high', overall_score: 0.9 },
+    },
+  }
+  styleState = { format: 'ieee' }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const open = () => render(<ShareModal checkId={42} title="Parity Paper" onClose={() => {}} />)
+
+const uncheck = (label) => {
+  const box = screen.getByLabelText(label, { exact: false })
+  fireEvent.click(box)
+}
+
+describe('publish paths carry the dialog’s report options', () => {
+  it('quick link sends the selected sections', async () => {
+    open()
+    uncheck('AI-text detection')
+    fireEvent.click(screen.getByText('Quick link'))
+
+    await waitFor(() => expect(publishCheck).toHaveBeenCalled())
+    const [, opts] = publishCheck.mock.calls[0]
+    expect(opts.adapter).toBe('quick_link')
+    expect(opts.include).toBeTruthy()
+    expect(opts.include.split(',')).not.toContain('ai')
+    expect(opts.include.split(',')).toContain('references')
+  })
+
+  it('publish to web sends the selected sections and the corrections flag', async () => {
+    open()
+    uncheck('Full reference list')
+    uncheck('Include suggested corrections')
+    fireEvent.click(screen.getByText('Publish to web'))
+    fireEvent.change(screen.getByPlaceholderText(/GitHub token/i), { target: { value: 'tok' } })
+    fireEvent.click(screen.getByText('Publish & get link'))
+
+    await waitFor(() => expect(publishCheck).toHaveBeenCalled())
+    const [, opts] = publishCheck.mock.calls[0]
+    expect(opts.adapter).toBe('github_gist')
+    expect(opts.corrections).toBe(true)
+    expect(opts.include.split(',')).not.toContain('references')
+  })
+
+  it('publishes the same canonical summary the download uses', async () => {
+    open()
+    fireEvent.click(screen.getByText('Quick link'))
+    await waitFor(() => expect(publishCheck).toHaveBeenCalled())
+    const publishSummary = publishCheck.mock.calls[0][1].summary
+
+    fireEvent.click(screen.getByText(/^Download/))
+    await waitFor(() => expect(exportCheckFile).toHaveBeenCalled())
+    const downloadSummary = exportCheckFile.mock.calls[0][1].summary
+
+    // Same numbers in the published link as in the downloaded file — otherwise
+    // a shared report disagrees with the badge the user is looking at.
+    expect(publishSummary).toEqual(downloadSummary)
+    expect(publishSummary).toBeTruthy()
+  })
+})

--- a/web-ui/src/utils/api.js
+++ b/web-ui/src/utils/api.js
@@ -281,8 +281,8 @@ export const exportCheckFile = (checkId, opts = {}) =>
   api.get(`/export/${checkId}/file?${_exportParams(opts)}`, { responseType: 'blob', timeout: 60000 })
 export const exportBatchFile = (batchId, opts = {}) =>
   api.get(`/export/batch/${batchId}/file?${_exportParams(opts)}`, { responseType: 'blob', timeout: 120000 })
-export const publishCheck = (checkId, { adapter = 'github_gist', token = '', public: isPublic = false } = {}) =>
-  api.post(`/export/${checkId}/publish`, { adapter, token, public: isPublic }, { timeout: 30000 })
+export const publishCheck = (checkId, { adapter = 'github_gist', token = '', public: isPublic = false, include, corrections = false, summary } = {}) =>
+  api.post(`/export/${checkId}/publish`, { adapter, token, public: isPublic, include, corrections, summary }, { timeout: 30000 })
 // Citation health + retraction (real signals).
 export const getCheckHealth = (checkId) => api.get(`/check/${checkId}/health`, { timeout: 15000 })
 export const getCheckRetractions = (checkId) => api.get(`/check/${checkId}/retractions`, { timeout: 45000 })


### PR DESCRIPTION
Audit for the same class of bug as the share-report fix in `41e0734` -- controls and code paths that look wired up but quietly drop what the user asked for. Four confirmed, each verified empirically before fixing.

| # | Issue | Impact |
|---|---|---|
| 1 | **Publish / Quick link ignored the share dialog options** | Every section checkbox and the *include corrections* toggle were discarded for shared links (they worked for downloads). The published report also missed the canonical style-aware summary, so a shared link could show **different counts** than the in-app badge. |
| 2 | **Single-reference re-verify could never report an error** | Its private copy of the batch logic folded `warning_type` into `error_type`, making `status="error"` unreachable -- a genuine author/DOI mismatch was shown as a mild **warning**. It also put warnings in `errors`, so the row rendered the *error* icon while its status said *warning*. Disagreed with the batch path on **4 of 5** representative cases. |
| 3 | **Cached-verification path judged titles by private rules** | `_diff_cited_vs_truth` used a raw token-set Jaccard with hand-picked 0.55/0.85 cut-offs instead of `calculate_title_similarity` + the shared `similarity_threshold`. The same reference could be **verified when checked fresh and warned when replayed from cache**. |
| 4 | **CrossRef DOI lookups returned list-valued titles** | The search paths unwrapped CrossRef's one-element lists; the DOI path didn't. The corrected reference shown to the user rendered with literal brackets and quotes, and string methods on it raise `AttributeError`. Confirmed against the live API. |

## Approach

Per `AGENTS.md`, each fix removes a private reimplementation rather than patching it:

- The canonical result classifier moves to **`backend/reference_status.py`**; the batch path and the re-verify endpoint now share it.
- The cached title comparison is anchored to the **shared scorer and shared threshold**. Accept at the shared threshold, "different work" below half of it, warn in between -- the half-threshold floor deliberately keeps spelling variants (`optimization`/`optimisation`) a warning instead of escalating them to a hard error.
- CrossRef normalizes in `get_work_by_doi`, so every lookup path returns one shape (also repairs already-cached raw entries).

`VERIFICATION_LOGIC_VERSION` -> **4**, since #3 changes verdicts for cached fuzzy hits.

## Verification

- **1812** Python unit tests pass (+44 new), **423** frontend tests pass.
- New tests assert the *absence* of the private logic (no Jaccard constants, no inline sanitizer) so it can't creep back.

## Negative results

Audited and found correctly wired: the remaining ShareModal/export controls, `referenceStatus.js` counting and filtering, `StatsSection` recompute, and the S2/OpenAlex/DBLP venue handling. One reported `_first_n_surnames` type bug was dismissed as unreachable in production (`truth` always comes from TEXT columns).